### PR TITLE
maint: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/pipeline-team
+* @honeycombio/frontend-observability
 


### PR DESCRIPTION
## Which problem is this PR solving?

Transfers ownership of this new repo from the default pipeline-team to frontend-observability.