### PR TITLE
docs: start docs files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,8 @@ Please see our [OSS process document](https://github.com/honeycombio/home/blob/m
 ## Short description of the changes
 
 ## How to verify that this has the expected result
+
+---
+
+- [ ] CHANGELOG is updated
+- [ ] README is updated with documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-# Honeycomb OpenTelemetry SDK Changelog
+# Honeycomb React Native SDK Changelog
 
 ## v.Next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
-# {project-name} changelog
+# Honeycomb OpenTelemetry SDK Changelog
 
+## v.Next

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,15 @@
+# Local Development
+
+## Prerequisites
+
+**Required:**
+
+TODO
+
+## Formatting
+
+TODO
+
+## Smoke Tests
+
+TODO

--- a/README.md
+++ b/README.md
@@ -1,10 +1,37 @@
-# Default Community Health Files
+# Honeycomb OpenTelemetry React Native
 
-This repository contains default community health files for repositories in the Honeycomb organization and will automatically be picked up if they are not overwritten.
+[![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/honeycomb-opentelemetry-react-native)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
+[![CircleCI](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-react-native.svg?style=shield)](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-react-native)
 
-More details on this repository structure can be found here: https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file
+Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) in React Native apps.
 
-# {project-name}
+**STATUS: this library is experimental.** Data shapes are unstable and subject to change. We are actively seeking feedback to ensure usability.
 
-<!-- OSS metadata badge - rename repo link and set status in OSSMETADATA -->
-<!-- [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/{repo-name})](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md) -->
+## Getting started
+
+### Adding the dependency
+
+TODO
+
+### Initializing the SDK
+
+TODO
+
+## Configuration Options
+
+| Option               | Type                           | Required? | Description                  |
+|----------------------|--------------------------------|-----------|------------------------------|
+
+## Default Attributes
+All spans will include the following attributes
+
+TODO
+
+## Auto-instrumentation
+
+TODO
+
+## Manual Instrumentation
+
+TODO
+


### PR DESCRIPTION
This PR creates the outline for doc files we know we'll want:
* A README with place for documentation.
* A DEVELOPING file with placeholders for setup instructions.
* An outline for CHANGELOG.
* A PR template checklist for updating README and CHANGELOG.