### PR TITLE
chore: Need to specify that this is a public npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## v.Next
 
-feat: Create `HoneycombReactNativeSDK` and `HoneycombReactNativeOptions`.
+- feat: Create `HoneycombReactNativeSDK` and `HoneycombReactNativeOptions`.
+- chore: Need to specify that this is a public npm package.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   },
   "homepage": "https://github.com/honeycombio/honeycomb-opentelemetry-react-native#readme",
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^19.6.0",


### PR DESCRIPTION
## Which problem is this PR solving?
The `release` step needs package.json to specify that this is intended to be published as a public package because we are nesting under the `@honeycombio` scope.

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation