### PR TITLE
feat: Add Release CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,6 @@ jobs:
       - run:
           name: store npm auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-      - run: npm run build
       - run: npm publish --access public
 
 filters_main_only: &filters_main_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,8 +164,9 @@ jobs:
       - run:
           name: store npm auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run: npm ci
       - run: npm run prepare
-      - run: npm run release
+      - run: npm publish --access public
 
 filters_main_only: &filters_main_only
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,14 @@ orbs:
   bats: circleci/bats@1.0.0
   macos: circleci/macos@2
 
+executors:
+  node:
+    docker:
+      - image: cimg/node:lts
+  github:
+    docker:
+      - image: cibuilds/github:0.13.0
+
 parameters:
   java-version:
     type: integer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,6 +189,10 @@ workflows:
           <<: *filters_always
       - smoke_tests_ios:
           <<: *filters_always
+        publish_npm:
+          <<: *filters_tags_only
+      - publish_github:
+          <<: *filters_tags_only
   nightly:
     triggers:
       - schedule:
@@ -202,4 +206,6 @@ workflows:
       - lint
       - smoke_tests_android
       - smoke_tests_ios
+      - publish_npm
+      - publish_github
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,24 @@ jobs:
           name: "Check Smoke Test Assertions"
           command: make smoke-bats
 
+  publish_github:
+    executor: github
+    steps:
+      - run:
+          name: "GHR Draft"
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG}
+
+  publish_npm:
+    executor: node
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: store npm auth token
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run: npm run build
+      - run: npm publish --access public
+
 filters_main_only: &filters_main_only
   filters:
     tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,8 @@ jobs:
       - run:
           name: store npm auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-      - run: npm publish --access public
+      - run: npm run prepare
+      - run: npm run release
 
 filters_main_only: &filters_main_only
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,10 +189,12 @@ workflows:
           <<: *filters_always
       - smoke_tests_ios:
           <<: *filters_always
-        publish_npm:
+      - publish_npm:
           <<: *filters_tags_only
+          context: Honeycomb Secrets for Public Repos
       - publish_github:
           <<: *filters_tags_only
+          context: Honeycomb Secrets for Public Repos
   nightly:
     triggers:
       - schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.Next
 
+- feat: Automatic Releasing via CI
 - feat: Navigation Instrumentation for Expo Router and React Native Router.
 - feat: Create `HoneycombReactNativeSDK` and `HoneycombReactNativeOptions`.
 - feat: Uncaught Exception handler

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,10 +2,12 @@
 
 This is a manual process for now, eventually this will move to CI without a manual `npm login` required.
 
-- Make sure [CHANGELOG.md](CHANGELOG.md) is up to date with the changes since the last release.
-- Run `npm login` and follow the prompts to log into npm.
-- Run `npm run release` and follow the prompts to release to GitHub and npm.
+- Create and checkout a release branch `release-x.y.z` for the release candidate.
+- Make sure [CHANGELOG.md](CHANGELOG.md) is up to date with the changes since the last release and the next release version.
 - Make sure the version in package.json is updated.
 - Commit changes, push, and open a release preparation pull request for review.
-- In the meantime, the release will go out so check the release notes in GitHub and publish the release.
-- Merge the release PR so that the `package.json` version is up to date.
+- Once all tests pass and the release is approved, you may merge the PR into main.
+- pull the latest version of main locally `git pull`
+- create a new tag for the release `git tag -a x.y.z -m x.y.z`
+- Push the tag, this will kick off the CI for releasing to NPM and create a draft GH release if successful. `git push x.y.z`
+- Once CI is completed, edit the draft release to match the changelog.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-This is a manual process for now, eventually this will move to CI without a manual `npm login` required.
+This is the process to release the Honeycomb OpenTelemetry React Native SDK to NPM
 
 - Create and checkout a release branch `release-x.y.z` for the release candidate.
 - Make sure [CHANGELOG.md](CHANGELOG.md) is up to date with the changes since the last release and the next release version.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
- We had a manual release process to get through fedex week. Now we are adding automated releases vis CircleCI.

- Closes #<enter issue here>

## Short description of the changes
Updates the CircleCI config and `RELEASING.md`  files to automatically release.

## How to verify that this has the expected result
We will be attempting a release later, if this works we will see it published in NPM.

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation