### PR TITLE
fix: clean up docs and fix publish command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: yarn install --frozen-lockfile
       - run: yarn prepare
-      - run: yarn publish --access public
+      - run: yarn npm publish --access public
 
 workflows:
   build:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,6 +8,7 @@ This is the process to release the Honeycomb OpenTelemetry React Native SDK to N
 - Commit changes, push, and open a release preparation pull request for review.
 - Once all tests pass and the release is approved, you may merge the PR into main.
 - pull the latest version of main locally `git pull`
-- create a new tag for the release `git tag -a x.y.z -m x.y.z`
-- Push the tag, this will kick off the CI for releasing to NPM and create a draft GH release if successful. `git push x.y.z`
+- create a new tag for the release `git tag -a v0.0.0 -m v0.0.0`
+- Push the tag. `git push 0.0.0`
+- this will kick off the CI for releasing to NPM and create a draft GH release if successful.
 - Once CI is completed, edit the draft release to match the changelog.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

docs needed to include `v` in tag for ci to pick up release tag. Additionally the publish command was incorrect.


- Closes #<enter issue here>

## Short description of the changes
- fixes docs inaccuracy by adding `v` to tag and push command examples
- corrects the publish command to `yarn npm publish` instead of the incorrect `yarn publish`.

## How to verify that this has the expected result

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation