### PR TITLE
fix: remove failing github action from release CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ orbs:
   bats: circleci/bats@1.0.0
   macos: circleci/macos@2
 
+executors:
+  github:
+    docker:
+      - image: cibuilds/github:0.13.0
+
 parameters:
   java-version:
     type: integer
@@ -174,6 +179,14 @@ jobs:
       - run: yarn prepare
       - run: npm publish --access public
 
+  publish_github:
+    executor: github
+    steps:
+      - run:
+          name: "GHR Draft"
+          command: ghr -draft -n 0.4.0 -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} 0.4.0
+
+
 workflows:
   build:
     jobs:
@@ -191,6 +204,9 @@ workflows:
           requires:
             - smoke_tests_ios
             - smoke_tests_android
+      - publish_github:
+          <<: *filters_always
+          context: Honeycomb Secrets for Public Repos
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,6 @@ orbs:
   bats: circleci/bats@1.0.0
   macos: circleci/macos@2
 
-executors:
-  github:
-    docker:
-      - image: cibuilds/github:0.13.0
-
 parameters:
   java-version:
     type: integer
@@ -165,13 +160,6 @@ jobs:
           name: "Check Smoke Test Assertions"
           command: make smoke-bats
 
-  publish_github:
-    executor: github
-    steps:
-      - run:
-          name: "GHR Draft"
-          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG}
-
   publish_npm:
     executor:
       name: android/android-machine
@@ -203,11 +191,6 @@ workflows:
           requires:
             - smoke_tests_ios
             - smoke_tests_android
-      - publish_github:
-          <<: *filters_tags_only
-          context: Honeycomb Secrets for Public Repos
-          requires:
-            - publish_npm
   nightly:
     triggers:
       - schedule:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,5 +11,5 @@ This is the process to release the Honeycomb OpenTelemetry React Native SDK to N
 - pull the latest version of main locally `git pull`
 - create a new tag for the release `git tag -a v0.0.0 -m v0.0.0`
 - Push the tag. `git push 0.0.0`
-- this will kick off the CI for releasing to NPM and create a draft GH release if successful.
-- Once CI is completed, edit the draft release to match the changelog.
+- this will kick off the CI for releasing to NPM
+- Once CI is completed, create a draft release based on the release notes.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Github is giving us a `404` when we try to create a new release using the APIs. 

- Closes #<enter issue here>

## Short description of the changes
Removing the github section of the release CI for now so as not to hold up releases.

## How to verify that this has the expected result
github removed from CI config and should not run at next release 

---

- [n/a] CHANGELOG is updated
- [n/a] README is updated with documentation