### PR TITLE
feat: add default instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v.Next
 
+- `fetch` and `uncaught exception` instrumentation are included and enabled by default.
+
 ## v0.3.0
 
 - feat: Automatic Releasing via CI

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ You can disable them by using the following configuration options:
 
 | Option                                                | Type                                   | Required? | default value     | Description                                              |
 |-------------------------------------------------------|----------------------------------------|-----------|-------------------|----------------------------------------------------------|
-| `uncaughtExceptionInstrumentationConfig`              | UncaughtExceptionInstrumentationConfig | No        | { enabled: true } | Whether to enable uncaught exception instrumentation.    |
-| `fetchInstrumentationConfig`                          | FetchInstrumentationConfig             | No        | { enabled: true } | Whether to enable fetch instrumentation.                 |
+| `uncaughtExceptionInstrumentationConfig`              | UncaughtExceptionInstrumentationConfig | No        | { enabled: true } | configuration for uncaught exception instrumentation.    |
+| `fetchInstrumentationConfig`                          | FetchInstrumentationConfig             | No        | { enabled: true } | configuration for fetch instrumentation.                 |
 
 
 ### Error handler

--- a/README.md
+++ b/README.md
@@ -50,24 +50,21 @@ TODO
 
 ## Auto-instrumentation
 
+The following auto-instrumentations are included by default:
+
+- Error Handler
+- Fetch Instrumentation
+
+You can disable them by using the following configuration options:
+
+| Option               | Type                           | Required? | Description                                                                      |
+|----------------------|--------------------------------|-----------|----------------------------------------------------------------------------------|
+| `uncaughtExceptionInstrumentationEnabled`             | Bool     | No        | Whether to enable uncaught exception instrumentation. (default: true) |
+| `fetchInstrumentationEnabled`.                        | Bool     | No        | Whether to enable fetch instrumentation. (default: true)              |
+
+
 ### Error handler
-The Honeycomb React Native SDK includes a global error handler for uncaught exceptions. To use it, include it in the `instrumentations` config property.
-
-```TypeScript
-import { 
-  HoneycombReactNativeSDK,
-  UncaughtExceptionInstrumentation,
-} from '@honeycombio/opentelemetry-react-native';
-
-const sdk = new HoneycombReactNativeSDK({
-  apiKey: 'api-key-goes-here',
-  serviceName: 'your-great-browser-application',
-  instrumentations: [
-    new UncaughtExceptionInstrumentation() // Any uncaught errors will be automatically recorded
-  ],
-});
-sdk.start();
-```
+The Honeycomb React Native SDK includes a global error handler for uncaught exceptions by default.
 
 ## Manual Instrumentation
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ The following auto-instrumentations are included by default:
 
 You can disable them by using the following configuration options:
 
-| Option               | Type                           | Required? | Description                                                                      |
-|----------------------|--------------------------------|-----------|----------------------------------------------------------------------------------|
-| `uncaughtExceptionInstrumentationEnabled`             | Bool     | No        | Whether to enable uncaught exception instrumentation. (default: true) |
-| `fetchInstrumentationEnabled`.                        | Bool     | No        | Whether to enable fetch instrumentation. (default: true)              |
+| Option                                                | Type                                   | Required? | default value     | Description                                              |
+|-------------------------------------------------------|----------------------------------------|-----------|-------------------|----------------------------------------------------------|
+| `uncaughtExceptionInstrumentationConfig`              | UncaughtExceptionInstrumentationConfig | No        | { enabled: true } | Whether to enable uncaught exception instrumentation.    |
+| `fetchInstrumentationConfig`                          | FetchInstrumentationConfig             | No        | { enabled: true } | Whether to enable fetch instrumentation.                 |
 
 
 ### Error handler

--- a/example/src/honeycomb.ts
+++ b/example/src/honeycomb.ts
@@ -1,8 +1,5 @@
 import { Platform } from 'react-native';
-import {
-  HoneycombReactNativeSDK,
-  UncaughtExceptionInstrumentation,
-} from '@honeycombio/opentelemetry-react-native';
+import { HoneycombReactNativeSDK } from '@honeycombio/opentelemetry-react-native';
 import { DiagLogLevel } from '@opentelemetry/api';
 
 const localhost = Platform.OS === 'android' ? '10.0.2.2' : 'localhost';
@@ -14,7 +11,6 @@ export const sdk = new HoneycombReactNativeSDK({
   endpoint: `http://${localhost}:4318`,
   serviceName: 'reactnative-example',
   logLevel: DiagLogLevel.DEBUG,
-  instrumentations: [new UncaughtExceptionInstrumentation()],
 });
 
 export function init() {

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
   },
   "dependencies": {
     "@honeycombio/opentelemetry-web": "^0.17.0",
-    "@opentelemetry/instrumentation": "^0.201.0"
+    "@opentelemetry/instrumentation": "^0.201.0",
+    "@opentelemetry/instrumentation-fetch": "^0.202.0"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,12 +5,14 @@ import {
   type HoneycombOptions,
   HoneycombWebSDK,
 } from '@honeycombio/opentelemetry-web';
-import type { UncaughtExceptionInstrumentationConfig } from './UncaughtExceptionInstrumentation';
 import {
   FetchInstrumentation,
   type FetchInstrumentationConfig,
 } from '@opentelemetry/instrumentation-fetch';
-import { UncaughtExceptionInstrumentation } from '../lib/typescript/commonjs/src';
+import {
+  UncaughtExceptionInstrumentation,
+  type UncaughtExceptionInstrumentationConfig,
+} from './UncaughtExceptionInstrumentation';
 
 export {
   UncaughtExceptionInstrumentation,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,8 @@ import {
   type HoneycombOptions,
   HoneycombWebSDK,
 } from '@honeycombio/opentelemetry-web';
+import type { UncaughtExceptionInstrumentationConfig } from './UncaughtExceptionInstrumentation';
+import type { FetchInstrumentationConfig } from '@opentelemetry/instrumentation-fetch';
 
 export {
   UncaughtExceptionInstrumentation,
@@ -20,7 +22,10 @@ export function multiply(a: number, b: number): number {
 /**
  * The options used to configure the Honeycomb React Native SDK.
  */
-interface HoneycombReactNativeOptions extends Partial<HoneycombOptions> {}
+interface HoneycombReactNativeOptions extends Partial<HoneycombOptions> {
+  uncaughtExceptionInstrumentationConfig: UncaughtExceptionInstrumentationConfig;
+  fetchInstrumentationConfig: FetchInstrumentationConfig;
+}
 
 /**
  * The entry point to Honeycomb in React Native apps.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,6 +1835,7 @@ __metadata:
     "@evilmartians/lefthook": ^1.5.0
     "@honeycombio/opentelemetry-web": ^0.17.0
     "@opentelemetry/instrumentation": ^0.201.0
+    "@opentelemetry/instrumentation-fetch": ^0.202.0
     "@react-native-community/cli": 15.0.1
     "@react-native/eslint-config": ^0.73.1
     "@react-navigation/native": 7.1.9
@@ -2494,6 +2495,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api-logs@npm:0.202.0":
+  version: 0.202.0
+  resolution: "@opentelemetry/api-logs@npm:0.202.0"
+  dependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 9a9f42df78b1bd7b481f51ae5c7ab1f6bf020e88d981bd3ef28db4a9752942801b31ace2ae77be53614e7a322528b2149132869d4ac40a14016a77f096bc8b5a
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:~1.9.0":
   version: 1.9.0
   resolution: "@opentelemetry/api@npm:1.9.0"
@@ -2525,6 +2535,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   checksum: 63a0792359c795425bd4fdb856b95f4eac4acf713e539f0926bdf08060e9dfa7741b24e6e9e10bcc49ff567baf914b41dc24a65f65df0eb97ea9348e70797a19
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@opentelemetry/core@npm:2.0.1"
+  dependencies:
+    "@opentelemetry/semantic-conventions": ^1.29.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: e1ac1f69a84d1e5e9bd8fb75f459f963c96e5adb4ffc5e7be35ae3100471c3337d053eab1d5dc3b5de68affb8ae0d72c1f229c0e067fa1679623d92fadd50a94
   languageName: node
   linkType: hard
 
@@ -2571,6 +2592,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-fetch@npm:^0.202.0":
+  version: 0.202.0
+  resolution: "@opentelemetry/instrumentation-fetch@npm:0.202.0"
+  dependencies:
+    "@opentelemetry/core": 2.0.1
+    "@opentelemetry/instrumentation": 0.202.0
+    "@opentelemetry/sdk-trace-web": 2.0.1
+    "@opentelemetry/semantic-conventions": ^1.29.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 6145504f92e26fd172431b0958b6071274dbdf1e554098b326a5c46014d3b690c47ef2bd0d95ab5e2d33d0e21c87f3eaf8f4c2f27cca3a7544fe8afce935150d
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-user-interaction@npm:^0.45.0":
   version: 0.45.0
   resolution: "@opentelemetry/instrumentation-user-interaction@npm:0.45.0"
@@ -2611,6 +2646,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 7850864f46fe2088828b11024a1ab7378350f2f1f1a65dc32176aa8fc19210443387a5d57360258997636bb86690de820ab9e39fd244dbe0ed7cb31188f269a9
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:0.202.0":
+  version: 0.202.0
+  resolution: "@opentelemetry/instrumentation@npm:0.202.0"
+  dependencies:
+    "@opentelemetry/api-logs": 0.202.0
+    import-in-the-middle: ^1.8.1
+    require-in-the-middle: ^7.1.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 9ad444dd66c258366427338e2f9f6534815a7235bc8d7bc8f5aae47fa27a2de76d79b1fa2e1434dc3fdc1745d979d13bda305fc190f1e90e79d75ab5a6837053
   languageName: node
   linkType: hard
 
@@ -2681,6 +2729,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/resources@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@opentelemetry/resources@npm:2.0.1"
+  dependencies:
+    "@opentelemetry/core": 2.0.1
+    "@opentelemetry/semantic-conventions": ^1.29.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: c6609739dba208d7b5fe17595cec391a27a774a7e2b9d9ff23d916269a4a5523422d7a8180f6256701f403d68e79e903145454476792b8d83551770a2e42df59
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-logs@npm:0.200.0":
   version: 0.200.0
   resolution: "@opentelemetry/sdk-logs@npm:0.200.0"
@@ -2719,6 +2779,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-trace-base@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@opentelemetry/sdk-trace-base@npm:2.0.1"
+  dependencies:
+    "@opentelemetry/core": 2.0.1
+    "@opentelemetry/resources": 2.0.1
+    "@opentelemetry/semantic-conventions": ^1.29.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: a1acccfdacee811b5cc42718679e8b5fb47ce0dfe26a128a8f8b8a54f726531d8582e2c3ddcfcd2b63f5f7c0d66ee6b6a30d0a931cf628fff7238931a564f80b
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-trace-web@npm:2.0.0, @opentelemetry/sdk-trace-web@npm:^2.0.0":
   version: 2.0.0
   resolution: "@opentelemetry/sdk-trace-web@npm:2.0.0"
@@ -2729,6 +2802,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   checksum: fec89d0664f80ef07d47a850d52a89d047276c4ba71ee0963b693ea91178bfe1544bcb145e1d4c9e6322be4a9f6da2d7b4caef470f800c5481eb1269b4a28c4a
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-web@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@opentelemetry/sdk-trace-web@npm:2.0.1"
+  dependencies:
+    "@opentelemetry/core": 2.0.1
+    "@opentelemetry/sdk-trace-base": 2.0.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 4cf53177d551e1389794561c3617a7e0d45f298e98f01b68ab6b814a4905a98eb9a1ed49e5f87d5c2b9a064e78b48ada47ca496575b03782ecb140e42e52a467
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Our web and mobile sdks all provide autoinstrumentation that is enabled by default with an option to disable them if desired.

- Closes #<enter issue here>

## Short description of the changes

Automatically adds instrumentation for `fetch` and uncaught exceptions with the option for disabling in the config. 

## How to verify that this has the expected result

Existing error tests should ensure this enables the instrumentation by default.

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation