### PR TITLE
feat: correct default resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v.Next
 
 - `fetch` and `uncaught exception` instrumentation are included and enabled by default.
+- Resources Attributes now match React native environment
+- OS name and version now included in resource attributes
 
 ## v0.3.0
 

--- a/package.json
+++ b/package.json
@@ -206,6 +206,8 @@
   "dependencies": {
     "@honeycombio/opentelemetry-web": "^0.17.0",
     "@opentelemetry/instrumentation": "^0.201.0",
-    "@opentelemetry/instrumentation-fetch": "^0.202.0"
+    "@opentelemetry/instrumentation-fetch": "^0.202.0",
+    "@opentelemetry/resources": "^2.0.1",
+    "@opentelemetry/semantic-conventions": "^1.34.0"
   }
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -15,6 +15,39 @@ setup_file() {
   assert_equal "$result" '"button-click"'
 }
 
+@test "Default resources are included on spans" {
+
+  result=$(resource_attributes_received | jq '.key' | sort | uniq)
+
+  assert_equal "$result" '"honeycomb.distro.runtime_version"
+"honeycomb.distro.version"
+"os.name"
+"os.version"
+"service.name"
+"telemetry.distro.name"
+"telemetry.distro.version"
+"telemetry.sdk.language"'
+}
+
+@test "Resources attributes are correct value" {
+
+  assert_not_empty "$(resource_attribute_named 'honeycomb.distro.version' 'string')"
+  assert_equal "$(resource_attribute_named 'honeycomb.distro.runtime_version' 'string' | uniq)" '"react native"'
+
+  assert_equal "$(resource_attribute_named 'telemetry.distro.name' 'string' | uniq)" '"@honeycombio/opentelemetry-react-native"'
+  assert_not_empty "$(resource_attribute_named 'telemetry.distro.version' 'string')"
+  assert_equal "$(resource_attribute_named 'telemetry.sdk.language' 'string' | uniq)" '"hermiesjs"'
+
+  osName=$(resource_attribute_named 'os.name' 'string' | uniq)
+  if [[ "$osName" == "android" ]]; then
+    assert_equal "$osname" '"android"'
+  else
+    assert_equal "$osName" '"ios"'
+  fi
+
+  assert_not_empty "$(resource_attribute_named 'os.version' 'string')"
+}
+
 @test "Uncaught Errors are recorded properly" {
   result=$(attribute_for_exception_trace_of_type "Error" "exception.message" "string")
   assert_equal "$result" '"test error"'

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -38,12 +38,7 @@ setup_file() {
   assert_not_empty "$(resource_attribute_named 'telemetry.distro.version' 'string')"
   assert_equal "$(resource_attribute_named 'telemetry.sdk.language' 'string' | uniq)" '"hermiesjs"'
 
-  osName=$(resource_attribute_named 'os.name' 'string' | uniq)
-  if [[ "$osName" == '"android"' ]]; then
-    assert_equal "$osName" '"android"'
-  else
-    assert_equal "$osName" '"ios"'
-  fi
+  assert_equal_or "$(resource_attribute_named 'os.name' 'string' | uniq)" '"android"' '"ios"'
 
   assert_not_empty "$(resource_attribute_named 'os.version' 'string')"
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -40,7 +40,7 @@ setup_file() {
 
   osName=$(resource_attribute_named 'os.name' 'string' | uniq)
   if [[ "$osName" == '"android"' ]]; then
-    assert_equal "$osname" '"android"'
+    assert_equal "$osName" '"android"'
   else
     assert_equal "$osName" '"ios"'
   fi

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -39,7 +39,7 @@ setup_file() {
   assert_equal "$(resource_attribute_named 'telemetry.sdk.language' 'string' | uniq)" '"hermiesjs"'
 
   osName=$(resource_attribute_named 'os.name' 'string' | uniq)
-  if [[ "$osName" == "android" ]]; then
+  if [[ "$osName" == '"android"' ]]; then
     assert_equal "$osname" '"android"'
   else
     assert_equal "$osName" '"ios"'

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -134,6 +134,32 @@ assert_equal() {
     fi
 }
 
+# Fail and display details if the expected does not match one of the values. 
+# Details include both values.
+#
+# Inspired by bats-assert * bats-support, but dramatically simplified
+# Arguments:
+# $1 - actual result
+# ${@:2:} - possible expected results
+assert_equal_or() {
+  local actual=$1
+
+  local expected=${@:2}
+
+  if ! [[ ${expected[@]} =~ $actual ]]; then
+    {
+        echo
+        echo "-- 💥 values are not equal 💥 --"
+        echo "expected : ${expected[@]}"
+        echo "actual   : $actual"
+        echo "--"
+        echo
+    } >&2 # output error to STDERR
+    return 1
+  fi
+
+}
+
 # Fail and display details if the actual value is empty.
 # Arguments: $1 - actual result
 assert_not_empty_string() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,19 @@ import {
   UncaughtExceptionInstrumentation,
   type UncaughtExceptionInstrumentationConfig,
 } from './UncaughtExceptionInstrumentation';
+import {
+  resourceFromAttributes,
+  type Resource,
+} from '@opentelemetry/resources';
+import {
+  ATTR_OS_NAME,
+  ATTR_OS_VERSION,
+  ATTR_TELEMETRY_DISTRO_NAME,
+  ATTR_TELEMETRY_DISTRO_VERSION,
+  ATTR_TELEMETRY_SDK_LANGUAGE,
+} from '@opentelemetry/semantic-conventions/incubating';
+import { VERSION } from './version';
+import { Platform } from 'react-native';
 
 export {
   UncaughtExceptionInstrumentation,
@@ -54,11 +67,32 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
       );
     }
 
+    let resource: Resource = resourceFromAttributes({
+      // Honeycomb distro attributes
+      'honeycomb.distro.version': VERSION,
+      'honeycomb.distro.runtime_version': 'react native',
+
+      // Opentelemetry attributes
+      [ATTR_TELEMETRY_DISTRO_NAME]: '@honeycombio/opentelemetry-react-native',
+      [ATTR_TELEMETRY_DISTRO_VERSION]: VERSION,
+      [ATTR_TELEMETRY_SDK_LANGUAGE]: 'hermiesjs',
+
+      // OS attributes
+      [ATTR_OS_NAME]: Platform.OS,
+      [ATTR_OS_VERSION]: Platform.Version,
+    });
+
+    if (options?.resource) {
+      resource = resource.merge(options.resource);
+    }
+
     super({
       ...options,
 
       // Add default instrumentations
       instrumentations,
+
+      resource,
 
       // Override web options that make no sense for React Native.
       disableBrowserAttributes: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,6 +1836,8 @@ __metadata:
     "@honeycombio/opentelemetry-web": ^0.17.0
     "@opentelemetry/instrumentation": ^0.201.0
     "@opentelemetry/instrumentation-fetch": ^0.202.0
+    "@opentelemetry/resources": ^2.0.1
+    "@opentelemetry/semantic-conventions": ^1.34.0
     "@react-native-community/cli": 15.0.1
     "@react-native/eslint-config": ^0.73.1
     "@react-navigation/native": 7.1.9
@@ -2729,7 +2731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:2.0.1":
+"@opentelemetry/resources@npm:2.0.1, @opentelemetry/resources@npm:^2.0.1":
   version: 2.0.1
   resolution: "@opentelemetry/resources@npm:2.0.1"
   dependencies:
@@ -2821,6 +2823,13 @@ __metadata:
   version: 1.30.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.30.0"
   checksum: 53d3489f11eeae07d12e878e4ae6df2de72b6a05ea434cfa2c2301023b9d3df35bcaafaeb294be708b93ae946b510067baf35008a3fd0275f52f0e0790014240
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:^1.34.0":
+  version: 1.34.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.34.0"
+  checksum: ea6a95616f9c0cc2c52439fe3966ff03ac21d9d0d906dca30246c23cee0152525eb6033a83a36951a52b7f1b043423bbb7aefe53d98cbb83feb9b0e91c8bc158
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Some resources were still emitting things specific to the web sdk. Others were not included.

- Closes #<enter issue here>

## Short description of the changes

Missing resource attributes were added and incorrect ones were overwritten.

## How to verify that this has the expected result

All spans emitted for bufeau-gotchi should include the correct resource attribute values when added. Automated tests have also been added.

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation