### PR TITLE
feat: add smoke tests for fetch auto-instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ project.xcworkspace
 .cxx
 .gradle
 .idea
+.kotlin
 .project
 .settings
 local.properties

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ smoke-docker: smoke-tests/collector/data.json
 	@echo ""
 	@echo "+++ Spinning up the smokers."
 	@echo ""
-	docker compose up --build react-native --build collector --detach
+	docker compose up --build react-native --build collector --build mock-server --detach
 
 unsmoke:
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -86,27 +86,6 @@ When a slow event loop is detected, it will emit a 'slow event loop' span with t
 |---------------------------|-----------------------------------------------------|---------|
 | `hermes.eventloop.delay` | The total time of the detected delay in miliseconds | `104`.  |
 
-### Fetch Instrumentation
-requests made using fetch can be added using the OpenTelemetry's [Fetch request instrumentation](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch) You may include this as follows.
-
-```TypeScript
-import { 
-  HoneycombReactNativeSDK,
-  UncaughtExceptionInstrumentation,
-} from '@honeycombio/opentelemetry-react-native';
-
-import { FetchInstrumentation } from "@opentelemetry/instrumentation-fetch";
-
-const sdk = new HoneycombReactNativeSDK({
-  apiKey: 'api-key-goes-here',
-  serviceName: 'your-great-browser-application',
-  instrumentations: [
-    new FetchInstrumentation() // All requests made with fetch will be recorded
-  ],
-});
-sdk.start();
-```
-
 ## Manual Instrumentation
 
 ### Navigation

--- a/README.md
+++ b/README.md
@@ -84,7 +84,28 @@ When a slow event loop is detected, it will emit a 'slow event loop' span with t
 
 | Field                     | Description                                         | Example |
 |---------------------------|-----------------------------------------------------|---------|
-| `hermies.eventloop.delay` | The total time of the detected delay in miliseconds | `104`.  |
+| `hermes.eventloop.delay` | The total time of the detected delay in miliseconds | `104`.  |
+
+### Fetch Instrumentation
+requests made using fetch can be added using the OpenTelemetry's [Fetch request instrumentation](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch) You may include this as follows.
+
+```TypeScript
+import { 
+  HoneycombReactNativeSDK,
+  UncaughtExceptionInstrumentation,
+} from '@honeycombio/opentelemetry-react-native';
+
+import { FetchInstrumentation } from "@opentelemetry/instrumentation-fetch";
+
+const sdk = new HoneycombReactNativeSDK({
+  apiKey: 'api-key-goes-here',
+  serviceName: 'your-great-browser-application',
+  instrumentations: [
+    new FetchInstrumentation() // All requests made with fetch will be recorded
+  ],
+});
+sdk.start();
+```
 
 ## Manual Instrumentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,9 @@ services:
       - './smoke-tests/collector:/var/lib'
     ports:
       - '4318:4318'
+  mock-server:
+    image: mockserver/mockserver
+    volumes:
+      - './smoke-tests/mock-server:/config'
+    ports:
+      - '1080:1080'

--- a/example/e2e/starter.test.ts
+++ b/example/e2e/starter.test.ts
@@ -24,6 +24,12 @@ describe('Example', () => {
     await element(by.id('send_trace')).tap();
   });
 
+  describe('network tests', () => {
+    it('should send a network request', async () => {
+      await element(by.id('send_network_request')).tap();
+    });
+  });
+
   describe('errors tests', () => {
     beforeEach(async () => {
       await waitFor(element(by.id('goto_errors')))

--- a/example/index.js
+++ b/example/index.js
@@ -1,3 +1,4 @@
+import 'react-native-url-polyfill/auto';
 import { AppRegistry } from 'react-native';
 import App from './src/App';
 import { name as appName } from './app.json';

--- a/example/ios/HoneycombOpentelemetryReactNativeExample/Info.plist
+++ b/example/ios/HoneycombOpentelemetryReactNativeExample/Info.plist
@@ -26,7 +26,6 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-	  <!-- Do not change NSAllowsArbitraryLoads to true, or you will risk app rejection! -->
 		<key>NSAllowsArbitraryLoads</key>
 		<false/>
 		<key>NSAllowsLocalNetworking</key>
@@ -34,6 +33,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>RCTNewArchEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1884,10 +1884,10 @@ SPEC CHECKSUMS:
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: bba368dacede4c9dec7a58c9be5a2d3e9ea30cc7
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: f493b0a600aed5dc06532141603688a30a5b2f61
   HoneycombOpentelemetryReactNative: 94c54ec5dba06cf07b9fed116b062921117f0a25
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 082fbc90409015eac1366795a0b90f8b5cb28efe
   RCTRequired: ca966f4da75b62ce3ea8c538d82cb5ecbb06f12a
   RCTTypeSafety: 2f0bc11f9584fde4c7e6d8b26577c97681051c00

--- a/example/package.json
+++ b/example/package.json
@@ -10,12 +10,14 @@
     "build:ios": "react-native build-ios --scheme HoneycombOpentelemetryReactNativeExample --mode Debug --extra-params \"-sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO\""
   },
   "dependencies": {
+    "@opentelemetry/instrumentation-fetch": "^0.202.0",
     "@react-navigation/native": "^7.1.9",
     "@react-navigation/native-stack": "^7.3.13",
     "react": "19.0.0",
     "react-native": "0.78.1",
     "react-native-safe-area-context": "^5.4.1",
-    "react-native-screens": "^4.11.0"
+    "react-native-screens": "^4.11.0",
+    "react-native-url-polyfill": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -5,11 +5,11 @@ import {
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import MainScreen from './MainScreen';
-import { init as honeyInit } from './honeycomb';
+import { init as initHoneycomb } from './honeycomb';
 import { NavigationInstrumentation } from '@honeycombio/opentelemetry-react-native';
 import ErrorScreen from './ErrorScreen';
 
-honeyInit();
+initHoneycomb();
 
 const RootStack = createNativeStackNavigator({
   screens: {

--- a/example/src/MainScreen.tsx
+++ b/example/src/MainScreen.tsx
@@ -1,7 +1,7 @@
 import { trace } from '@opentelemetry/api';
 import { useState } from 'react';
 import { Button, Text, View, StyleSheet } from 'react-native';
-import { sdk } from './honeycomb';
+import { localhost, sdk } from './honeycomb';
 import { useNavigation } from '@react-navigation/native';
 
 function onTraceClick() {
@@ -10,6 +10,16 @@ function onTraceClick() {
     .startSpan('button-click');
   console.log('the trace button was clicked!');
   span.end();
+}
+
+async function sendNetworkRequest() {
+  const url = new URL(`http://${localhost}:1080/simple-api`);
+  try {
+    const response = await fetch(url);
+    console.log(response);
+  } catch (e) {
+    console.error(e);
+  }
 }
 
 export default function MainScreen() {
@@ -31,6 +41,13 @@ export default function MainScreen() {
         testID="send_trace"
         color="#841584"
         accessibilityLabel="send_trace_button"
+      />
+      <Button
+        onPress={sendNetworkRequest}
+        title="Send a network request"
+        testID="send_network_request"
+        color="#841584"
+        accessibilityLabel="send_network_request"
       />
       <Button
         onPress={onFlushClick}

--- a/example/src/honeycomb.ts
+++ b/example/src/honeycomb.ts
@@ -2,9 +2,9 @@ import { Platform } from 'react-native';
 import { HoneycombReactNativeSDK } from '@honeycombio/opentelemetry-react-native';
 import { DiagLogLevel } from '@opentelemetry/api';
 
-const localhost = Platform.OS === 'android' ? '10.0.2.2' : 'localhost';
+export const localhost = Platform.OS === 'android' ? '10.0.2.2' : 'localhost';
 
-//Swaps out the default error handler so we can test errors
+// Swaps out the default error handler so we can test errors
 ErrorUtils.setGlobalHandler(() => {});
 
 export const sdk = new HoneycombReactNativeSDK({

--- a/smoke-tests/mock-server/README.md
+++ b/smoke-tests/mock-server/README.md
@@ -1,5 +1,5 @@
 # mock-server
 
-We use a simple node server to provide simple API endpoints we can hit from our example app and smoke tests.
+We use [mock-server](https://www.mock-server.com) to provide simple API endpoints we can hit from our example app and smoke tests.
 
-Endpoints and their responses are configured in `index.js`
+Endpoints and their responses are configured in `mock-server.json`

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -64,6 +64,9 @@ setup_file() {
 }
 
 @test "Network auto-instrumentation sends spans" {
-  result=$(attribute_for_span_key "@opentelemetry/instrumentation-fetch" "HTTP GET" "http.url" "string" | sort | uniq)
+  result=$(attribute_for_span_key "@opentelemetry/instrumentation-fetch" "HTTP GET" "http.url" "string" \
+    | sort \
+    | uniq \
+    | sed -e 's/10.0.2.2/localhost/')  # because android uses a different address
   assert_equal "$result" '"http://localhost:1080/simple-api"'
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -30,13 +30,12 @@ setup_file() {
 }
 
 @test "Resources attributes are correct value" {
-
   assert_not_empty "$(resource_attribute_named 'honeycomb.distro.version' 'string')"
   assert_equal "$(resource_attribute_named 'honeycomb.distro.runtime_version' 'string' | uniq)" '"react native"'
 
   assert_equal "$(resource_attribute_named 'telemetry.distro.name' 'string' | uniq)" '"@honeycombio/opentelemetry-react-native"'
   assert_not_empty "$(resource_attribute_named 'telemetry.distro.version' 'string')"
-  assert_equal "$(resource_attribute_named 'telemetry.sdk.language' 'string' | uniq)" '"hermiesjs"'
+  assert_equal "$(resource_attribute_named 'telemetry.sdk.language' 'string' | uniq)" '"hermesjs"'
 
   assert_equal_or "$(resource_attribute_named 'os.name' 'string' | uniq)" '"android"' '"ios"'
 
@@ -61,6 +60,10 @@ setup_file() {
 
 @test "Slow event loop events are recorded" {
   result=$(span_names_for "@honeycombio/slow-event-loop" | uniq)
-
   assert_equal "$result" '"slow event loop"'
+}
+
+@test "Network auto-instrumentation sends spans" {
+  result=$(attribute_for_span_key "@opentelemetry/instrumentation-fetch" "HTTP GET" "http.url" "string" | sort | uniq)
+  assert_equal "$result" '"http://localhost:1080/simple-api"'
 }

--- a/src/SlowEventLoopInstrumentation.ts
+++ b/src/SlowEventLoopInstrumentation.ts
@@ -138,7 +138,7 @@ export class SlowEventLoopInstrumentation extends InstrumentationAbstract {
 
     // hermes is not listed in the JS semantic conventions so we
     // are going to use the `hermes` namespace and the node/web/v8 naming convention
-    slowEventLoopSpan.setAttribute('hermies.eventloop.delay', delayMs);
+    slowEventLoopSpan.setAttribute('hermes.eventloop.delay', delayMs);
 
     if (this.applyCustomAttributesOnSpan) {
       this.applyCustomAttributesOnSpan(slowEventLoopSpan, {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,7 +86,7 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
       // Opentelemetry attributes
       [ATTR_TELEMETRY_DISTRO_NAME]: '@honeycombio/opentelemetry-react-native',
       [ATTR_TELEMETRY_DISTRO_VERSION]: VERSION,
-      [ATTR_TELEMETRY_SDK_LANGUAGE]: 'hermiesjs',
+      [ATTR_TELEMETRY_SDK_LANGUAGE]: 'hermesjs',
 
       // OS attributes
       [ATTR_OS_NAME]: Platform.OS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3650,11 +3650,11 @@ __metadata:
   linkType: hard
 
 "@types/node-forge@npm:^1.3.0":
-  version: 1.3.11
-  resolution: "@types/node-forge@npm:1.3.11"
+  version: 1.3.12
+  resolution: "@types/node-forge@npm:1.3.12"
   dependencies:
     "@types/node": "*"
-  checksum: 1e86bd55b92a492eaafd75f6d01f31e7d86a5cdadd0c6bcdc0b1df4103b7f99bb75b832efd5217c7ddda5c781095dc086a868e20b9de00f5a427ddad4c296cd5
+  checksum: 233ca1022dd65875c8453862cbcbb254573c771a8c0f06d27f93b914cb84fbd0a6b1947498fcf1d0035d64ff2fcbb17f45b3b0e447fccee0651116a7c492a3f7
   languageName: node
   linkType: hard
 
@@ -4601,7 +4601,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.5.0":
+"buffer@npm:^5.4.3, buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -7592,6 +7592,7 @@ __metadata:
     "@babel/core": ^7.25.2
     "@babel/preset-env": ^7.25.3
     "@babel/runtime": ^7.25.0
+    "@opentelemetry/instrumentation-fetch": ^0.202.0
     "@react-native-community/cli": 15.0.1
     "@react-native-community/cli-platform-android": 15.0.1
     "@react-native-community/cli-platform-ios": 15.0.1
@@ -7610,6 +7611,7 @@ __metadata:
     react-native-builder-bob: ^0.38.4
     react-native-safe-area-context: ^5.4.1
     react-native-screens: ^4.11.0
+    react-native-url-polyfill: ^2.0.0
   languageName: unknown
   linkType: soft
 
@@ -9777,6 +9779,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-babel-transformer@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-babel-transformer@npm:0.81.5"
+  dependencies:
+    "@babel/core": ^7.25.2
+    flow-enums-runtime: ^0.0.6
+    hermes-parser: 0.25.1
+    nullthrows: ^1.1.1
+  checksum: 687b0657fcb2c6a01784a29abaa9979539a9047c0632c299d7764e7cafa9412cbb17f4e866212dc4c96a73eb47381d30340b30628b2d083fef0c88523ae0a293
+  languageName: node
+  linkType: hard
+
 "metro-cache-key@npm:0.80.12":
   version: 0.80.12
   resolution: "metro-cache-key@npm:0.80.12"
@@ -9792,6 +9806,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: ^0.0.6
   checksum: 524f11de4b907024d27de1f190ea8520e3bd7ffa9cfa6d7d4c1a067ad41e4f2acd5b40c756c5dbf0def3e2dfaa5e0780fb54f7d960cd7888c124d44905b1dcfa
+  languageName: node
+  linkType: hard
+
+"metro-cache-key@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-cache-key@npm:0.81.5"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+  checksum: d5656bc8906ff4366d8093d19304d6ac386c59429e3e7e24050f4bc9f93ca4e04d8062af6bdd28874a5e4b9bcc84f248855933ffa80af56aeed8be5ff02c85bf
   languageName: node
   linkType: hard
 
@@ -9814,6 +9837,17 @@ __metadata:
     flow-enums-runtime: ^0.0.6
     metro-core: 0.81.4
   checksum: 61e5e129a7eed60ea7b85224df145b959ee3379eab0f5f6d00d9268ee549ff411347e0cfe1738a827d1070ec0bacc225473c80f6cf72780bc3a81a518d5e0ec6
+  languageName: node
+  linkType: hard
+
+"metro-cache@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-cache@npm:0.81.5"
+  dependencies:
+    exponential-backoff: ^3.1.1
+    flow-enums-runtime: ^0.0.6
+    metro-core: 0.81.5
+  checksum: cba822d3f5c38163558e8240f7b8f189a597829c7df07a3f205c9565f66c0d3a9d7deab7be9449dec3bd1c615b71918c8cd05b0e2bf9cc21c517702405d468d1
   languageName: node
   linkType: hard
 
@@ -9849,6 +9883,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-config@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-config@npm:0.81.5"
+  dependencies:
+    connect: ^3.6.5
+    cosmiconfig: ^5.0.5
+    flow-enums-runtime: ^0.0.6
+    jest-validate: ^29.7.0
+    metro: 0.81.5
+    metro-cache: 0.81.5
+    metro-core: 0.81.5
+    metro-runtime: 0.81.5
+  checksum: 43ba163fcfcbd0bcf69c3416901779c3de94536b0ee451ad73cad6311734e931cb1bf2c007dd71317f35ddf346cca74bc07b5a3075adf5c09b0e6e859d2169e4
+  languageName: node
+  linkType: hard
+
 "metro-core@npm:0.80.12":
   version: 0.80.12
   resolution: "metro-core@npm:0.80.12"
@@ -9860,7 +9910,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-core@npm:0.81.4, metro-core@npm:^0.81.0":
+"metro-core@npm:0.81.4":
   version: 0.81.4
   resolution: "metro-core@npm:0.81.4"
   dependencies:
@@ -9868,6 +9918,17 @@ __metadata:
     lodash.throttle: ^4.1.1
     metro-resolver: 0.81.4
   checksum: d39d5e25dbb949fdeae906c511b78ee19a2caee2ddd018116866715263038baf4be8376255ee0087f892ee7220aeb17f9c8cabbd244742100dc9e87193614f91
+  languageName: node
+  linkType: hard
+
+"metro-core@npm:0.81.5, metro-core@npm:^0.81.0":
+  version: 0.81.5
+  resolution: "metro-core@npm:0.81.5"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+    lodash.throttle: ^4.1.1
+    metro-resolver: 0.81.5
+  checksum: 5fb02d055669f0d37aaffc165444aa723741e9e9a74c1e17c54b53e635e4b7246d8ec582bfb951710ff02cd2d26d5565811182464f3f42728c1f346d0e699f8a
   languageName: node
   linkType: hard
 
@@ -9911,6 +9972,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-file-map@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-file-map@npm:0.81.5"
+  dependencies:
+    debug: ^2.2.0
+    fb-watchman: ^2.0.0
+    flow-enums-runtime: ^0.0.6
+    graceful-fs: ^4.2.4
+    invariant: ^2.2.4
+    jest-worker: ^29.7.0
+    micromatch: ^4.0.4
+    nullthrows: ^1.1.1
+    walker: ^1.0.7
+  checksum: dcc975a6a3a0ceaf25048cca834d6b065b719b768f332c2a720d6a0341b6b640783625d1188dc1b85204e42420853240fa0419988bade2395ce3c054079c3b65
+  languageName: node
+  linkType: hard
+
 "metro-minify-terser@npm:0.80.12":
   version: 0.80.12
   resolution: "metro-minify-terser@npm:0.80.12"
@@ -9931,6 +10009,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-minify-terser@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-minify-terser@npm:0.81.5"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+    terser: ^5.15.0
+  checksum: 4623743676e2bb8bb74b99bd2b2c26feb2509a8db5596f265e21042b43e84611f9025977ae298b8271644cb27e8da8a60b8dff791f57517b4bd2f5ae366f2945
+  languageName: node
+  linkType: hard
+
 "metro-resolver@npm:0.80.12":
   version: 0.80.12
   resolution: "metro-resolver@npm:0.80.12"
@@ -9946,6 +10034,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: ^0.0.6
   checksum: 0404d549ac144d5823e4b0383e6718d5fb969c60f3cf4db4a24748f94198b692b1527a92a874b9af00ba28284719063e7aaec5f2913e82438ac5b97d9b406241
+  languageName: node
+  linkType: hard
+
+"metro-resolver@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-resolver@npm:0.81.5"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+  checksum: 84d9f3c10538a747c2718ddc1cf366c38b1a6080e2b6cdfd4731511e5a25cec45fbf35101fae8691bda59fd2e9aa3f559d436bc46e05b603c446072e4a1bc6e9
   languageName: node
   linkType: hard
 
@@ -9969,6 +10066,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-runtime@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-runtime@npm:0.81.5"
+  dependencies:
+    "@babel/runtime": ^7.25.0
+    flow-enums-runtime: ^0.0.6
+  checksum: 43b54e07ce0534928c12f59a3d2e68ecf4fc7e7ad1a78cb691f90a406796eec381af21fcef5af73ecc5081153a4da5f935797ebe9ea4a025a5e526039bf19b21
+  languageName: node
+  linkType: hard
+
 "metro-source-map@npm:0.80.12":
   version: 0.80.12
   resolution: "metro-source-map@npm:0.80.12"
@@ -9986,7 +10093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-source-map@npm:0.81.4, metro-source-map@npm:^0.81.0":
+"metro-source-map@npm:0.81.4":
   version: 0.81.4
   resolution: "metro-source-map@npm:0.81.4"
   dependencies:
@@ -10001,6 +10108,24 @@ __metadata:
     source-map: ^0.5.6
     vlq: ^1.0.0
   checksum: 878fe5b2e69f3b658e80f50de61ca8af8085485dfffb67ec1641e80e725a87319cbcf51909ac56baaafcf6156a3a4ba78585901a164d237566b6a19767341633
+  languageName: node
+  linkType: hard
+
+"metro-source-map@npm:0.81.5, metro-source-map@npm:^0.81.0":
+  version: 0.81.5
+  resolution: "metro-source-map@npm:0.81.5"
+  dependencies:
+    "@babel/traverse": ^7.25.3
+    "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3"
+    "@babel/types": ^7.25.2
+    flow-enums-runtime: ^0.0.6
+    invariant: ^2.2.4
+    metro-symbolicate: 0.81.5
+    nullthrows: ^1.1.1
+    ob1: 0.81.5
+    source-map: ^0.5.6
+    vlq: ^1.0.0
+  checksum: a31e459c8a18fe3fc6b3cc5d87a2f25b2f3794425d590bbbab8abafa537647110b18edd0ff025971d1783e16d3c114099bf13c406a01a6456e3e004a54f621d8
   languageName: node
   linkType: hard
 
@@ -10037,6 +10162,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-symbolicate@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-symbolicate@npm:0.81.5"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+    invariant: ^2.2.4
+    metro-source-map: 0.81.5
+    nullthrows: ^1.1.1
+    source-map: ^0.5.6
+    vlq: ^1.0.0
+  bin:
+    metro-symbolicate: src/index.js
+  checksum: f1ec6df153be8b469c87179dcc0807e6e94e2523140e0b0044aa2fecedfd222f9d05a408bd142d3293e52e9c7ef59064332fce5f489cddb0f38d11d3ed897c2b
+  languageName: node
+  linkType: hard
+
 "metro-transform-plugins@npm:0.80.12":
   version: 0.80.12
   resolution: "metro-transform-plugins@npm:0.80.12"
@@ -10062,6 +10203,20 @@ __metadata:
     flow-enums-runtime: ^0.0.6
     nullthrows: ^1.1.1
   checksum: 709e7a2ea8fef04d40dc63222cb9b42046b975c1b7eb838c6f9ca315e08a756ad18d0057f2d5e0beaf4e0561cd03be9dfb3b15de286ff102ee386cf49acbae57
+  languageName: node
+  linkType: hard
+
+"metro-transform-plugins@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-transform-plugins@npm:0.81.5"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/generator": ^7.25.0
+    "@babel/template": ^7.25.0
+    "@babel/traverse": ^7.25.3
+    flow-enums-runtime: ^0.0.6
+    nullthrows: ^1.1.1
+  checksum: 2d156882c6545730638aeb362856288649e5049f336d532040dd4b9435ad53d35adbc808903f01519dfda5e7a9a1d80b6f2303171921f32aa823f86484ab2b60
   languageName: node
   linkType: hard
 
@@ -10104,6 +10259,27 @@ __metadata:
     metro-transform-plugins: 0.81.4
     nullthrows: ^1.1.1
   checksum: 947b892b0dc8836d55772d0367ed0a797fc68f8b53000e21be5b5c6cc66ab0269292e4cbff3fa9988f4c471dbd979a49dbb11fa780e7022e0ed26b810cbe19ff
+  languageName: node
+  linkType: hard
+
+"metro-transform-worker@npm:0.81.5":
+  version: 0.81.5
+  resolution: "metro-transform-worker@npm:0.81.5"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/generator": ^7.25.0
+    "@babel/parser": ^7.25.3
+    "@babel/types": ^7.25.2
+    flow-enums-runtime: ^0.0.6
+    metro: 0.81.5
+    metro-babel-transformer: 0.81.5
+    metro-cache: 0.81.5
+    metro-cache-key: 0.81.5
+    metro-minify-terser: 0.81.5
+    metro-source-map: 0.81.5
+    metro-transform-plugins: 0.81.5
+    nullthrows: ^1.1.1
+  checksum: 59d144c44e7979317ee702a0f11da19443e5bf56a4fb6be026e4e09377631a2704ca4aba4e7290711fbe481176e82006fe195a18cacd6007f01c6b1ebe2a7a84
   languageName: node
   linkType: hard
 
@@ -10159,7 +10335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro@npm:0.81.4, metro@npm:^0.81.0":
+"metro@npm:0.81.4":
   version: 0.81.4
   resolution: "metro@npm:0.81.4"
   dependencies:
@@ -10206,6 +10382,56 @@ __metadata:
   bin:
     metro: src/cli.js
   checksum: 77d8ffa230500f9e7f834600d9d8a4a8b0a3214f17e3dd4e8b8c2039bd48e3d8322e01068b4faf29093fa8398225cef4a6f130b581c33fef53e94f5646e6e1a9
+  languageName: node
+  linkType: hard
+
+"metro@npm:0.81.5, metro@npm:^0.81.0":
+  version: 0.81.5
+  resolution: "metro@npm:0.81.5"
+  dependencies:
+    "@babel/code-frame": ^7.24.7
+    "@babel/core": ^7.25.2
+    "@babel/generator": ^7.25.0
+    "@babel/parser": ^7.25.3
+    "@babel/template": ^7.25.0
+    "@babel/traverse": ^7.25.3
+    "@babel/types": ^7.25.2
+    accepts: ^1.3.7
+    chalk: ^4.0.0
+    ci-info: ^2.0.0
+    connect: ^3.6.5
+    debug: ^2.2.0
+    error-stack-parser: ^2.0.6
+    flow-enums-runtime: ^0.0.6
+    graceful-fs: ^4.2.4
+    hermes-parser: 0.25.1
+    image-size: ^1.0.2
+    invariant: ^2.2.4
+    jest-worker: ^29.7.0
+    jsc-safe-url: ^0.2.2
+    lodash.throttle: ^4.1.1
+    metro-babel-transformer: 0.81.5
+    metro-cache: 0.81.5
+    metro-cache-key: 0.81.5
+    metro-config: 0.81.5
+    metro-core: 0.81.5
+    metro-file-map: 0.81.5
+    metro-resolver: 0.81.5
+    metro-runtime: 0.81.5
+    metro-source-map: 0.81.5
+    metro-symbolicate: 0.81.5
+    metro-transform-plugins: 0.81.5
+    metro-transform-worker: 0.81.5
+    mime-types: ^2.1.27
+    nullthrows: ^1.1.1
+    serialize-error: ^2.1.0
+    source-map: ^0.5.6
+    throat: ^5.0.0
+    ws: ^7.5.10
+    yargs: ^17.6.2
+  bin:
+    metro: src/cli.js
+  checksum: 7665b811aa09abe5c7743764402f03cf64ccb3e1b381a46716470b58b05a952dde45e5e34c6a485f79154e2905b89fc178455c378831f9425767d76392418f9f
   languageName: node
   linkType: hard
 
@@ -10756,6 +10982,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: ^0.0.6
   checksum: 76369043728f471ded35d294088e65a3c0876f2f7c73ad9a4dcdda68e1022a4ce72b8052a681f2604c93cd2e7ccf35e945bbb01855378122f7a1ef48ad1cc72c
+  languageName: node
+  linkType: hard
+
+"ob1@npm:0.81.5":
+  version: 0.81.5
+  resolution: "ob1@npm:0.81.5"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+  checksum: 249ad576be69151a3099207b35b2f6da5c6bb39dfacb9295028ebdc182c2f61f6544d1f6f167af759a77174ab19d8997d1ae6aecdbd9bdc293b2826067e66c5b
   languageName: node
   linkType: hard
 
@@ -11550,7 +11785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0":
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: bb0a0ceedca4c3c57a9b981b90601579058903c62be23c5e8e843d2c2d4148a3ecf029d5133486fb0e1822b098ba8bba09e89d6b21742d02fa26bda6441a6fb2
@@ -11630,12 +11865,12 @@ __metadata:
   linkType: hard
 
 "react-devtools-core@npm:^6.0.1":
-  version: 6.1.1
-  resolution: "react-devtools-core@npm:6.1.1"
+  version: 6.1.5
+  resolution: "react-devtools-core@npm:6.1.5"
   dependencies:
     shell-quote: ^1.6.1
     ws: ^7
-  checksum: 18b6d11a11a23b67eb1ff7d44b45adb914a18d9b26cdb378d8f3146834eda5d9bdefc131bb7fb793f3057f166c309681651e865814bbf491f2ea0d0bf06a2922
+  checksum: b54f2d2416f5f5ca61b1741367865eab18b0040d7e4b3236693595803dfdf82ae02adbcb480acc5b9767748b615a2d5ce3af286cde3a7f8c193123c62c777428
   languageName: node
   linkType: hard
 
@@ -11739,6 +11974,17 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 29ab15641e96c11c5035475e80b14ba0018d8e96f6f1320aa5eea83fa82b34604ad57242a59728e1b2a465a1cf33f716740bd943fd8473daf4bb2c11449b9ee8
+  languageName: node
+  linkType: hard
+
+"react-native-url-polyfill@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "react-native-url-polyfill@npm:2.0.0"
+  dependencies:
+    whatwg-url-without-unicode: 8.0.0-3
+  peerDependencies:
+    react-native: "*"
+  checksum: 1a2e1030a62fd093764b5330ce0ff34d72246e581dd2892cddc347d8621931aeb2c9ea3e054960484a1259230e8461e569e1890f1ff452d3c5c0adef70190fc3
   languageName: node
   linkType: hard
 
@@ -13899,10 +14145,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "webidl-conversions@npm:5.0.0"
+  checksum: ccf1ec2ca7c0b5671e5440ace4a66806ae09c49016ab821481bec0c05b1b82695082dc0a27d1fe9d804d475a408ba0c691e6803fd21be608e710955d4589cd69
+  languageName: node
+  linkType: hard
+
 "whatwg-fetch@npm:^3.0.0":
   version: 3.6.20
   resolution: "whatwg-fetch@npm:3.6.20"
   checksum: c58851ea2c4efe5c2235f13450f426824cf0253c1d45da28f45900290ae602a20aff2ab43346f16ec58917d5562e159cd691efa368354b2e82918c2146a519c5
+  languageName: node
+  linkType: hard
+
+"whatwg-url-without-unicode@npm:8.0.0-3":
+  version: 8.0.0-3
+  resolution: "whatwg-url-without-unicode@npm:8.0.0-3"
+  dependencies:
+    buffer: ^5.4.3
+    punycode: ^2.1.1
+    webidl-conversions: ^5.0.0
+  checksum: 1fe266f7161e0bd961087c1254a5a59d1138c3d402064495eed65e7590d9caed5a1d9acfd6e7a1b0bf0431253b0e637ee3e4ffc08387cd60e0b2ddb9d4687a4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Which problem is this PR solving?

This adds a smoke test for `fetch` auto-instrumentation.

## Short description of the changes

* Adds a `mock-server` docker config, like we use for iOS and Android http instrumentation tests.
* Adds a `"Send a network request"` button to the example app.
* Adds a smoke test that clicks the new button and asserts the expected telemetry is collected.
* Adds `react-native-url-polyfill` to the example app, to fix problems with React Native's `URL` class.
* Fixes various minor typos, such as "hermies" to "hermes".

## How to verify that this has the expected result

* The smoke tests pass.

---

~- [ ] CHANGELOG is updated~ N/A
~- [ ] README is updated with documentation~ N/A