### PR TITLE
feat: android native modules

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -97,6 +97,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "io.honeycomb.android:honeycomb-opentelemetry-android:0.0.11"
   implementation "io.opentelemetry:opentelemetry-api:1.49.0"
+  implementation "io.opentelemetry.semconv:opentelemetry-semconv-incubating:1.30.0-alpha"
   implementation "io.opentelemetry.android:core:0.11.0-alpha"
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,6 +67,7 @@ android {
   }
 
   compileOptions {
+    coreLibraryDesugaringEnabled true
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
@@ -89,8 +90,14 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
+
+  // This is required by opentelemetry-android.
+  coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation "io.honeycomb.android:honeycomb-opentelemetry-android:0.0.11"
+  implementation "io.opentelemetry:opentelemetry-api:1.49.0"
+  implementation "io.opentelemetry.android:core:0.11.0-alpha"
 }
 
 react {

--- a/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
+++ b/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
@@ -11,13 +11,23 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
     return NAME
   }
 
-  // Example method
-  // See https://reactnative.dev/docs/native-modules-android
-  override fun multiply(a: Double, b: Double): Double {
-    return a * b
-  }
-
   companion object {
     const val NAME = "HoneycombOpentelemetryReactNative"
+
+    const val otelRum = null;
+
+    fun configure() : void {
+                val options =
+            HoneycombOptions
+                .builder()
+                .setApiKey("test-key")
+                .setApiEndpoint("http://10.0.2.2:4318")
+                .setServiceName("reactnative-example")
+                .setMetricsDataset("reactnative-example-metrics")
+                .setDebug(true)
+                .build()
+
+        otelRum = Honeycomb.configure(this, options)
+    }
   }
 }

--- a/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
+++ b/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
@@ -1,7 +1,14 @@
 package com.honeycombopentelemetryreactnative
 
+import android.app.Application
+
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModule
+
+import io.opentelemetry.android.OpenTelemetryRum
+
+import io.honeycomb.opentelemetry.android.Honeycomb
+import io.honeycomb.opentelemetry.android.HoneycombOptions
 
 @ReactModule(name = HoneycombOpentelemetryReactNativeModule.NAME)
 class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationContext) :
@@ -14,12 +21,12 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
   companion object {
     const val NAME = "HoneycombOpentelemetryReactNative"
 
-    const val otelRum = null;
+    var otelRum : OpenTelemetryRum? = null
 
-    fun configure() : void {
-                val options =
+    fun configure(app: Application) {
+            val options =
             HoneycombOptions
-                .builder()
+                .builder(app)
                 .setApiKey("test-key")
                 .setApiEndpoint("http://10.0.2.2:4318")
                 .setServiceName("reactnative-example")
@@ -27,7 +34,7 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
                 .setDebug(true)
                 .build()
 
-        otelRum = Honeycomb.configure(this, options)
+        otelRum = Honeycomb.configure(app, options)
     }
   }
 }

--- a/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
+++ b/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModule
 
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME
 
 import io.honeycomb.opentelemetry.android.Honeycomb
 import io.honeycomb.opentelemetry.android.HoneycombOptions
@@ -24,17 +25,21 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
     var otelRum : OpenTelemetryRum? = null
 
     fun configure(app: Application) {
-            val options =
-            HoneycombOptions
-                .builder(app)
-                .setApiKey("test-key")
-                .setApiEndpoint("http://10.0.2.2:4318")
-                .setServiceName("reactnative-example")
-                .setMetricsDataset("reactnative-example-metrics")
-                .setDebug(true)
-                .build()
+      val options =
+        HoneycombOptions
+          .builder(app)
+          .setApiKey("test-key")
+          .setApiEndpoint("http://10.0.2.2:4318")
+          .setServiceName("reactnative-example")
+          .setMetricsDataset("reactnative-example-metrics")
+          .setResourceAttributes(mapOf( 
+            TELEMETRY_DISTRO_NAME.key to "@honeycombio/opentelemetry-react-native",
+            "honeycomb.distro.runtime_version" to "react native",
+            "telemetry.sdk.language" to "hermesjs"))
+          .setDebug(true)
+          .build()
 
-        otelRum = Honeycomb.configure(app, options)
+      otelRum = Honeycomb.configure(app, options)
     }
   }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -108,9 +108,18 @@ android {
             proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
         }
     }
+
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
+
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
+
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -122,6 +131,8 @@ dependencies {
 
     androidTestImplementation('com.wix:detox:+')
     implementation 'androidx.appcompat:appcompat:1.1.0'
+
+    implementation "io.opentelemetry.android:android-agent:0.11.0-alpha"
 }
 
 // Run Codegen during development for the example app.

--- a/example/android/app/src/main/java/honeycombopentelemetryreactnative/example/MainApplication.kt
+++ b/example/android/app/src/main/java/honeycombopentelemetryreactnative/example/MainApplication.kt
@@ -12,6 +12,8 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
 
+import com.honeycombopentelemetryreactnative.HoneycombOpentelemetryReactNativeModule
+
 class MainApplication : Application(), ReactApplication {
 
   override val reactNativeHost: ReactNativeHost =
@@ -34,6 +36,7 @@ class MainApplication : Application(), ReactApplication {
     get() = getDefaultReactHost(applicationContext, reactNativeHost)
 
   override fun onCreate() {
+    HoneycombOpentelemetryReactNativeModule.configure(this)
     super.onCreate()
     SoLoader.init(this, OpenSourceMergedSoMapping)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -19,14 +19,23 @@ setup_file() {
 
   result=$(resource_attributes_received | jq '.key' | sort | uniq)
 
-  assert_equal "$result" '"honeycomb.distro.runtime_version"
+  assert_equal "$result" '"device.id"
+"device.manufacturer"
+"device.model.identifier"
+"device.model.name"
+"honeycomb.distro.runtime_version"
 "honeycomb.distro.version"
+"os.description"
 "os.name"
+"os.type"
 "os.version"
+"rum.sdk.version"
 "service.name"
 "telemetry.distro.name"
 "telemetry.distro.version"
-"telemetry.sdk.language"'
+"telemetry.sdk.language"
+"telemetry.sdk.name"
+"telemetry.sdk.version"'
 }
 
 @test "Resources attributes are correct value" {
@@ -37,7 +46,7 @@ setup_file() {
   assert_not_empty "$(resource_attribute_named 'telemetry.distro.version' 'string')"
   assert_equal "$(resource_attribute_named 'telemetry.sdk.language' 'string' | uniq)" '"hermesjs"'
 
-  assert_equal_or "$(resource_attribute_named 'os.name' 'string' | uniq)" '"android"' '"ios"'
+  assert_equal_or "$(resource_attribute_named 'os.name' 'string' | awk '{print tolower($0)}' | uniq)" '"android"' '"ios"'
 
   assert_not_empty "$(resource_attribute_named 'os.version' 'string')"
 }

--- a/src/NativeHoneycombOpentelemetryReactNative.ts
+++ b/src/NativeHoneycombOpentelemetryReactNative.ts
@@ -1,9 +1,7 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
-export interface Spec extends TurboModule {
-  multiply(a: number, b: number): number;
-}
+export interface Spec extends TurboModule {}
 
 export default TurboModuleRegistry.getEnforcing<Spec>(
   'HoneycombOpentelemetryReactNative'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 export { NavigationInstrumentation } from './NavigationInstrumentation';
-import HoneycombOpentelemetryReactNative from './NativeHoneycombOpentelemetryReactNative';
 
 import {
   type HoneycombOptions,
@@ -41,12 +40,6 @@ export {
   UncaughtExceptionInstrumentation,
   type UncaughtExceptionInstrumentationConfig,
 } from './UncaughtExceptionInstrumentation';
-
-// This function is an example of how to proxy native code.
-// TODO: Remove this, once we have other native code.
-export function multiply(a: number, b: number): number {
-  return HoneycombOpentelemetryReactNative.multiply(a, b);
-}
 
 /**
  * The options used to configure the Honeycomb React Native SDK.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,11 +17,19 @@ import {
   type Resource,
 } from '@opentelemetry/resources';
 import {
+  ATTR_DEVICE_ID,
+  ATTR_DEVICE_MANUFACTURER,
+  ATTR_DEVICE_MODEL_IDENTIFIER,
+  ATTR_DEVICE_MODEL_NAME,
+  ATTR_OS_DESCRIPTION,
   ATTR_OS_NAME,
+  ATTR_OS_TYPE,
   ATTR_OS_VERSION,
   ATTR_TELEMETRY_DISTRO_NAME,
   ATTR_TELEMETRY_DISTRO_VERSION,
   ATTR_TELEMETRY_SDK_LANGUAGE,
+  ATTR_TELEMETRY_SDK_NAME,
+  ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions/incubating';
 
 import { VERSION } from './version';
@@ -80,10 +88,21 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
       [ATTR_TELEMETRY_DISTRO_NAME]: '@honeycombio/opentelemetry-react-native',
       [ATTR_TELEMETRY_DISTRO_VERSION]: VERSION,
       [ATTR_TELEMETRY_SDK_LANGUAGE]: 'hermesjs',
+      [ATTR_TELEMETRY_SDK_NAME]: 'opentelemetry',
+      [ATTR_TELEMETRY_SDK_VERSION]: VERSION,
 
       // OS attributes
       [ATTR_OS_NAME]: Platform.OS,
       [ATTR_OS_VERSION]: Platform.Version,
+      [ATTR_OS_DESCRIPTION]: Platform.OS,
+      [ATTR_OS_TYPE]: Platform.OS,
+
+      // Stubbed out attributes
+      [ATTR_DEVICE_ID]: '',
+      [ATTR_DEVICE_MANUFACTURER]: '',
+      [ATTR_DEVICE_MODEL_IDENTIFIER]: '',
+      [ATTR_DEVICE_MODEL_NAME]: '',
+      'rum.sdk.version': '',
     });
 
     if (options?.resource) {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Adds the honeycomb opentelemetry android library to the the react native library. Values are currently hard-coded but will 

- Closes #<enter issue here>

## Short description of the changes

## How to verify that this has the expected result

Telemetry data gets emitted in example app from native extensions.

---

- [n/a] CHANGELOG is updated
- [n/a] README is updated with documentation