### PR TITLE
feat: slow event loop matches time and duration of slow loop

### DIFF
--- a/src/SlowEventLoopInstrumentation.ts
+++ b/src/SlowEventLoopInstrumentation.ts
@@ -115,7 +115,7 @@ export class SlowEventLoopInstrumentation extends InstrumentationAbstract {
     ) {
       this._emitSlowEventLoopSpan({
         delayMs: intervalSinceLastCheck,
-        timestampMs: nowTimestamp,
+        timestampMs: this._lastLoopTimestamp,
       });
     }
 
@@ -147,7 +147,7 @@ export class SlowEventLoopInstrumentation extends InstrumentationAbstract {
       });
     }
 
-    slowEventLoopSpan.end();
+    slowEventLoopSpan.end(timestampMs + delayMs);
   }
 
   private _suspendResumeHandler(appState: AppStateStatus): void {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
slow event loop spans when put on session timeline only showed duration as a property. 

- Closes #<enter issue here>

## Short description of the changes

This changes it so that the span starts when the event loop begins and ends when it returns. Thus showing the period of time when the slow event loop took place. 

## How to verify that this has the expected result

---

- [ ] CHANGELOG is updated
- [ ] README is updated with documentation