### PR TITLE
feat: sync session ID between TypeScript and native SDKs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   smoke_tests_ios:
     macos:
       xcode: 16.2.0
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
 
     steps:
       - attach_workspace:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,20 @@
 
 ## v.Next
 
-## v.0.4.0
+- feat: Sync session ID between TypeScript and native SDKs.
 
-- `fetch` and `uncaught exception` instrumentation are included and enabled by default.
-- Resources Attributes now match React native environment
-- OS name and version now included in resource attributes
-- slow event loop autoinstrumentation
+## v0.4.0
+
+- feat: `fetch` and `uncaught exception` instrumentation are included and enabled by default
+- feat: Resources Attributes now match React native environment
+- feat: OS name and version now included in resource attributes
+- feat: Slow event loop auto-instrumentation
 
 ## v0.3.0
 
 - feat: Automatic Releasing via CI
 - feat: Navigation Instrumentation for Expo Router and React Native Router.
-- feat: Create `HoneycombReactNativeSDK` and `HoneycombReactNativeOptions`.
+- feat: Create `HoneycombReactNativeSDK` and `HoneycombReactNativeOptions`
 - feat: Uncaught Exception handler
-- feat: Create `HoneycombReactNativeSDK` and `HoneycombReactNativeOptions`.
-- chore: Need to specify that this is a public npm package.
+- feat: Create `HoneycombReactNativeSDK` and `HoneycombReactNativeOptions`
+- chore: Need to specify that this is a public npm package

--- a/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
+++ b/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
@@ -19,6 +19,10 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
     return NAME
   }
 
+  override fun getSessionId(): String? {
+    return HoneycombOpentelemetryReactNativeModule.otelRum?.rumSessionId
+  }
+
   companion object {
     const val NAME = "HoneycombOpentelemetryReactNative"
 
@@ -32,7 +36,7 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
           .setApiEndpoint("http://10.0.2.2:4318")
           .setServiceName("reactnative-example")
           .setMetricsDataset("reactnative-example-metrics")
-          .setResourceAttributes(mapOf( 
+          .setResourceAttributes(mapOf(
             TELEMETRY_DISTRO_NAME.key to "@honeycombio/opentelemetry-react-native",
             "honeycomb.distro.runtime_version" to "react native",
             "telemetry.sdk.language" to "hermesjs"))

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.78.1):
     - hermes-engine/Pre-built (= 0.78.1)
   - hermes-engine/Pre-built (0.78.1)
-  - HoneycombOpentelemetryReactNative (0.3.0):
+  - HoneycombOpentelemetryReactNative (0.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1884,72 +1884,72 @@ SPEC CHECKSUMS:
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: bba368dacede4c9dec7a58c9be5a2d3e9ea30cc7
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: f493b0a600aed5dc06532141603688a30a5b2f61
-  HoneycombOpentelemetryReactNative: 9a1d4a08ab1616c0fbd8c8880fd4845bd74a3bb3
+  HoneycombOpentelemetryReactNative: a61f17824a1ba33908e2af2dd159cccbb8bd0e36
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 082fbc90409015eac1366795a0b90f8b5cb28efe
   RCTRequired: ca966f4da75b62ce3ea8c538d82cb5ecbb06f12a
   RCTTypeSafety: 2f0bc11f9584fde4c7e6d8b26577c97681051c00
   React: e6035d3a639f6668a18429aaf2fdc0c12b1e7a81
   React-callinvoker: 3740fb1716428dabd205486c818ce6a5999e7f11
-  React-Core: d12b31b149ff71e5054dec137d651a9955569321
-  React-CoreModules: e392c711449f260d9ba7556a264ef5cfacdab3f9
-  React-cxxreact: dcb3c48b13b298a270edefb24d2a9211809ff147
+  React-Core: 91dda08e72d07375f41dc7ea00550804e0198282
+  React-CoreModules: 5ff502f2c460a74f77ec38164db50886516f403e
+  React-cxxreact: a064be4dcb707678007f90d17739f6a677c6c3de
   React-debug: 2307e4eaa3f21be31182aabc6aa6cde1931703a7
-  React-defaultsnativemodule: 60728861bf5b03fa213fd11542dcc5f87a4a3477
-  React-domnativemodule: a01a1868cd0d9df3a0c2aaec02c2869dfecd72b8
-  React-Fabric: 4d8b5732b48fee439af4153a1f5b50e8d9f26193
-  React-FabricComponents: 516ad7e5ac6f855c98df38238b3a6a586b05584c
-  React-FabricImage: b468b8e61e41d3b32650e556e40ff9bb28b75d58
+  React-defaultsnativemodule: 2ae0e30cdb335562dc3f3fba5fb4d8288a2d0942
+  React-domnativemodule: 509f12582d13fadb10361d1df1288b55d5e75baa
+  React-Fabric: 67b6780b8e1c3d7d6e585a268f5d1e54a16ec472
+  React-FabricComponents: 0134bdb1f35f7f8357c7648d49671e176f5151d9
+  React-FabricImage: dc15141d01afa465de904652a3b57e10e58cdf56
   React-featureflags: d9f1c9549c740be588405cf32f46815dde40da68
-  React-featureflagsnativemodule: 5133d429178fee252bd0b5fcb204c75c496b88a5
-  React-graphics: 53b9fa98a8cbe838e80d20a2cb242d2f1e9db249
-  React-hermes: 809429058aa7610601c552556a132df2f446fe0c
-  React-idlecallbacksnativemodule: 3b39fcbd2535ba43f05ae599666b532cc6d25154
-  React-ImageManager: 5ceb67a153ec8f25e0ff56bc40d2172b2d3e57d9
-  React-jserrorhandler: 1843c869e47d73e152f209bf5fd06ebd40ee9aaa
-  React-jsi: 0be2628a04b7ab6b60565ccc0e11069c6a3e5a91
-  React-jsiexecutor: cb431019ea945006b0ad62ba34dba8475926eda9
-  React-jsinspector: dabe35a99fa7fb088e1dad0f1cc97f2fa398f4c6
-  React-jsinspectortracing: 1d274806cfafd5c3133d7aaab354caf0dc0f3cb7
-  React-jsitracing: ed46156c5ad71f7736894d1387a54cf1b39c6df7
-  React-logger: 74ddb793d36b48bba176328c7af75e5e656fd405
-  React-Mapbuffer: 9089a8ef738526aa31bb993debfaff214c2bef5d
-  React-microtasksnativemodule: d4fd1d752f04965cd989beb8d28e896fa7f58605
-  react-native-safe-area-context: 0472f170cbc594668dc7923724f679b066ac75b7
-  React-NativeModulesApple: ce75ed8f1188483be3620bf9dbb3b1286dd39bab
-  React-perflogger: 26d07766b033f84559bd520e949453dba8bf1cd8
-  React-performancetimeline: 24eb0a6a341a1b0d48bc75a961ee480db0bad47e
+  React-featureflagsnativemodule: f67095fbb9b0387b1089f699fb8cddc1880d5344
+  React-graphics: 78850ac1948cdf389b87901114b649a24fed8002
+  React-hermes: d61c104904d2c5a2cb9390267085c17f284f149e
+  React-idlecallbacksnativemodule: 689e3d9e15583df257baa3511b4c3a2de5143f12
+  React-ImageManager: f0ac3380c7cb1dd511d43548b9d7fbce6df00dde
+  React-jserrorhandler: f1c13545ca63cf25586eaf115f97a9f3f1996664
+  React-jsi: 183f5f851fee72238c1ac807bbca39f9930d22cf
+  React-jsiexecutor: afee0663c97f2d32188e1b91fe16fc09377b5ce7
+  React-jsinspector: 38f63d8b58d49ecb873d153ab897173baf6e48a8
+  React-jsinspectortracing: 1e3427c3119901a5c2a3acdaa5891d1cd96cebaa
+  React-jsitracing: c158c22d2ae0b666e00588e7d08ae28200c4289a
+  React-logger: 88de26ac2b4ae3ebf55108f4be299f967151d0ec
+  React-Mapbuffer: 8b09f543e16b4b46f014113e90dfa7a8d75892b6
+  React-microtasksnativemodule: c552278ee39f89a9fc4ffbe0bf9316d1cf3c8729
+  react-native-safe-area-context: 52678968e2d1e05ecdd6246348d7f1c4259aa6e1
+  React-NativeModulesApple: 1e30b3e42b7632af111ae8e1e29d7f212a68ab0f
+  React-perflogger: e1c8cc9ba55dfabb670966d73622eabcfa0ac29e
+  React-performancetimeline: c02e4180f8e815a0423d109849493c4bb643cc06
   React-RCTActionSheet: 9488eac05a056a124f500beaecf0a5bd722b2916
-  React-RCTAnimation: d4fe0beca00060dc3628d81ea65410180974a18a
-  React-RCTAppDelegate: 6c81adc5689b4276368c9dc61eec211b18ca82c0
-  React-RCTBlob: 1b89799400af7ca0ee598fa7d3bcd9d84ab1794d
-  React-RCTFabric: b4b568442d7468ad25126f8de3bbd51a010f10ee
-  React-RCTFBReactNativeSpec: 9487cf2e72e2b0da766afe2a71e1afca12e73325
-  React-RCTImage: 7042262e823fe7849f1263f054c24ef2f4394e9d
-  React-RCTLinking: 7cb75b965f19399f67e75f771f7bd6f097c263d1
-  React-RCTNetwork: b9a7eab793a36b3a74d4d184b917e59842a30a58
-  React-RCTSettings: 7866a50ecc34b202d736d1f4b9164bb711a68a9c
-  React-RCTText: ce131e974c81c0ea4a187f24db12b262a1beab01
-  React-RCTVibration: 16c24efa3a7fb96f6147ec129d554cc43b1ab707
+  React-RCTAnimation: 25cab7e810ceffcbecaf80d481e8da88458fe16d
+  React-RCTAppDelegate: bc7081822fadf0ef7b0103ad7a1906d2872b1f4e
+  React-RCTBlob: 878e2cc90c812b6fd0a311d26f16c7a7d6fb3383
+  React-RCTFabric: c73cd20dcb076386e29261fae9d5cfd5d6160615
+  React-RCTFBReactNativeSpec: 992688432b262346c956a316b9b554496af4d21e
+  React-RCTImage: 86722acf9b025c586aaf27d7428e8f85a51a32fa
+  React-RCTLinking: e8e3c957074d5d37081e62c87f7c0896c1e9fb29
+  React-RCTNetwork: 49a1ef2960b23016d2e02707612696293e43cee5
+  React-RCTSettings: ad5b561160ea88c2cd117d7546d850840b5aca0a
+  React-RCTText: af6b82a41a437d5dec61946fb3d8fe93c059a039
+  React-RCTVibration: 7894e99bec0902b50dd630347421f03e34560e02
   React-rendererconsistency: 31f87e51559385f02f7abbfa33b49ef84f87934b
-  React-rendererdebug: 644562dd21dd432899408e400d1d6380f56921ae
+  React-rendererdebug: 590d068638efa691ed57f035561455e9bbb8e126
   React-rncore: c39f07475d066378ef0de9158400005de9d76c20
-  React-RuntimeApple: 202bc9390ebfa4588c5322ab9dbdfde3c33d8e16
-  React-RuntimeCore: 038a6112dfa27eab1621c8ffaa09ea8add054c5b
+  React-RuntimeApple: b1b60cc5fca53efccbb4ad8dc87d5bc3a3f4bc0d
+  React-RuntimeCore: 7f8b1ac6c22e83b9d3564e907780393b6f36fb1d
   React-runtimeexecutor: f2fc17f0bbfa5a697d94d2f18d7d5f74c8d41c48
-  React-RuntimeHermes: 79b804c832efa7705a017d9b716f52172a00e8db
-  React-runtimescheduler: ed0cc6ec2dedd42598c813e8c35cfe75d170303c
+  React-RuntimeHermes: 9f833c570593a880bb938b808425d8361a995863
+  React-runtimescheduler: d60bc1d2b5f196d8b85c37a95061b6139f334e5e
   React-timing: 1c7cad05d27fb9c5f02bcb988d1e39dac344d144
-  React-utils: 656f3b31bdcdda2008a54f9b370f1267ae985d04
-  ReactAppDependencyProvider: 5da0393968ce2767e79f9fda7caa108592b9b63e
-  ReactCodegen: 5e0e4a579d3492d4cb81ed7caadbaae66a619b7e
-  ReactCommon: 00e8f55183ce1358c920a954cd588831ccf0c397
-  RNScreens: ae16e299dbce21ef5774e29707a0f96a1276f35c
+  React-utils: 8bb9a97cdabc2f6281955e2cef3f29214f9dd3dd
+  ReactAppDependencyProvider: 8a4769a6193da471cb229cf46e71cd11cd9a4acd
+  ReactCodegen: 684a73edf1b470489d78a9be498a442d7ce55112
+  ReactCommon: 646c9fb7fd3db3f1c4fdef21c045363cbd15aa2d
+  RNScreens: 93062d301c0e67bcb1ce35bf0f8e3abe0bfc5543
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 464c847c822847c88560af530ca15273b8e45261
+  Yoga: 0745771e552e45bec48d0723fbb0e745c26f4abc
 
 PODFILE CHECKSUM: 862f324354bdd78226a22c6aca426bb952b750ad
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/ios/HoneycombOpentelemetryReactNative.mm
+++ b/ios/HoneycombOpentelemetryReactNative.mm
@@ -1,4 +1,5 @@
 #import "HoneycombOpentelemetryReactNative.h"
+#import <HoneycombOpentelemetryReactNative/HoneycombOpentelemetryReactNative-Swift.h>
 
 @implementation HoneycombOpentelemetryReactNative
 RCT_EXPORT_MODULE()
@@ -7,6 +8,10 @@ RCT_EXPORT_MODULE()
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
     return std::make_shared<facebook::react::NativeHoneycombOpentelemetryReactNativeSpecJSI>(params);
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getSessionId) {
+  return [HoneycombWrapper sessionId];
 }
 
 @end

--- a/ios/HoneycombReactNative.mm
+++ b/ios/HoneycombReactNative.mm
@@ -3,8 +3,7 @@
 
 @implementation HoneycombReactNative
 
-+ (void) configure {
-
++ (void)configure {
   [HoneycombWrapper configure];
 }
 

--- a/ios/HoneycombWrapper.swift
+++ b/ios/HoneycombWrapper.swift
@@ -3,21 +3,25 @@ import Honeycomb
 @objc public class HoneycombWrapper : NSObject {
   @objc public static func configure() {
     do {
-        let options = try HoneycombOptions.Builder()
-            .setAPIKey("test-key")
-            .setServiceName("reactnative-example")
-            .setAPIEndpoint("http://localhost:4318")
-            .setDebug(true)
+      let options = try HoneycombOptions.Builder()
+        .setAPIKey("test-key")
+        .setServiceName("reactnative-example")
+        .setAPIEndpoint("http://localhost:4318")
+        .setDebug(true)
       
-            // This produces a lot of extra UI events that are not particularly helpful
-            .setUIKitInstrumentationEnabled(false)
+        // This produces a lot of extra UI events that are not particularly helpful
+        .setUIKitInstrumentationEnabled(false)
       
-            // This locks up react native.
-            .setURLSessionInstrumentationEnabled(false)
-            .build()
-        try Honeycomb.configure(options: options)
+        // This locks up react native.
+        .setURLSessionInstrumentationEnabled(false)
+        .build()
+      try Honeycomb.configure(options: options)
     } catch {
-        NSException(name: NSExceptionName("HoneycombOptionsError"), reason: "\(error)").raise()
+      NSException(name: NSExceptionName("HoneycombOptionsError"), reason: "\(error)").raise()
     }
+  }
+
+  @objc public static func sessionId() -> String? {
+    return Honeycomb.currentSession()?.id
   }
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -51,6 +51,15 @@ setup_file() {
   assert_not_empty "$(resource_attribute_named 'os.version' 'string')"
 }
 
+@test "Session ID is synced between TypeScript and native SDKs" {
+  result=$(spans_received \
+    | jq .scopeSpans[]?.spans[]?.attributes[] \
+    | jq 'select (.key == "session.id").value.stringValue' \
+    | sort | uniq | wc -l | tr -d ' ')
+
+  assert_equal "$result" "1"
+}
+
 @test "Uncaught Errors are recorded properly" {
   result=$(attribute_for_exception_trace_of_type "Error" "exception.message" "string")
   assert_equal "$result" '"test error"'

--- a/src/NativeHoneycombOpentelemetryReactNative.ts
+++ b/src/NativeHoneycombOpentelemetryReactNative.ts
@@ -1,7 +1,9 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
-export interface Spec extends TurboModule {}
+export interface Spec extends TurboModule {
+  getSessionId(): string | null;
+}
 
 export default TurboModuleRegistry.getEnforcing<Spec>(
   'HoneycombOpentelemetryReactNative'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
-export { NavigationInstrumentation } from './NavigationInstrumentation';
-
+import HoneycombOpentelemetryReactNative from './NativeHoneycombOpentelemetryReactNative';
 import {
   type HoneycombOptions,
   HoneycombWebSDK,
@@ -31,23 +30,29 @@ import {
   ATTR_TELEMETRY_SDK_NAME,
   ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions/incubating';
-
 import { VERSION } from './version';
 import { Platform } from 'react-native';
 import {
   SlowEventLoopInstrumentation,
   type SlowEventLoopInstrumentationConfig,
 } from './SlowEventLoopInstrumentation';
+import { type SessionProvider } from '@opentelemetry/web-common';
 
+export { NavigationInstrumentation } from './NavigationInstrumentation';
 export {
   SlowEventLoopInstrumentation,
   type SlowEventLoopInstrumentationConfig,
 } from './SlowEventLoopInstrumentation';
-
 export {
   UncaughtExceptionInstrumentation,
   type UncaughtExceptionInstrumentationConfig,
 } from './UncaughtExceptionInstrumentation';
+
+class SessionIdProvider implements SessionProvider {
+  getSessionId(): string | null {
+    return HoneycombOpentelemetryReactNative.getSessionId();
+  }
+}
 
 /**
  * The options used to configure the Honeycomb React Native SDK.
@@ -122,11 +127,11 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
 
       // Add default instrumentations
       instrumentations,
-
       resource,
 
       // Override web options that make no sense for React Native.
       disableBrowserAttributes: true,
+      sessionProvider: new SessionIdProvider(),
       webVitalsInstrumentationConfig: {
         enabled: false,
       },


### PR DESCRIPTION
## Which problem is this PR solving?

Syncs session ID between TypeScript and native SDKs.

## Short description of the changes

Adds a new `SessionIdProvider` to the TypeScript config that calls into the native layer to get the native SDK's session id.

We may want to do something more sophisticated in the future, but this seems like a good first pass.

## How to verify that this has the expected result

* New smoke tests added.
* Manually inspected output.

---

- [X] CHANGELOG is updated
~- [ ] README is updated with documentation~ N/A