### PR TITLE
docs: Include build configuration in Native Modules docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v.Next
 
+- docs: Native Module documentation updated to include important configuration steps.
+
 ## v0.5.0
 
 - feat: Sync session ID between TypeScript and native SDKs.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sdk.start();
 
 4. Android (optional)
 
-Add the following dependency to your apps build.gradle
+ a. Add the following dependency to your apps build.gradle.
 
 ```Kotlin
 dependencies {
@@ -41,7 +41,25 @@ dependencies {
 }
 ```
 
-Add the following lines to the beginning of your `MainApplication.kt`'s  `onCreate` method
+ b. If your min SDK version is below 26, you will likely need to add core library desugaring to your android gradle build.
+
+`android/app/build.gradle`
+```diff
+android {
+  //
+  compileOptions {
++   coreLibraryDesugaringEnabled true
+    //...
+  }
+
+  //...
+  dependencies {
++   coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
+  }
+}
+```
+
+ c. Add the following lines to the beginning of your `MainApplication.kt`'s  `onCreate` method.
 
 ```Kotlin
 override fun onCreate() {
@@ -57,9 +75,16 @@ override fun onCreate() {
 
 5. iOS (optional)
 
-  a. Go to your app's `ios` directory and run `pod install` then
+  a. Edit your app's podfile to add the `use_frameworks!` option. 
 
-  b. Add the following lines to the beginning your `AppDelegate.swift`'s application method
+```diff
+  platform :ios, min_ios_version_supported
+  prepare_react_native_project!
++ use_frameworks!
+```
+  b. Go to your app's `ios` directory and run `pod install` then
+
+  c. Add the following lines to the beginning your `AppDelegate.swift`'s application method
 
 ```swift
 override func application(

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ override fun onCreate() {
 
   a. Edit your app's podfile to add the `use_frameworks!` option. 
 
+`ios/Podfile`
 ```diff
   platform :ios, min_ios_version_supported
   prepare_react_native_project!


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When setting up a React Native application to use Native Modules, the `Podfile` on iOS and the `build.gradle` file in android both need additional configuration in order to build properly.

- Closes #<enter issue here>

## Short description of the changes

Updates the Readme to include steps to update the native build files.

## How to verify that this has the expected result

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation