### PR TITLE
docs: fix errors in native modules setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ sdk.start();
 
 4. Android (optional)
 
- a. Add the following dependency to your apps build.gradle.
+ a. Add the following dependencies to your apps build.gradle.
 
 ```Kotlin
 dependencies {
     //...
     implementation "io.honeycomb.android:honeycomb-opentelemetry-android:0.0.16"
+    implementation "io.opentelemetry.android:android-agent:0.11.0-alpha"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,8 @@ override func application(
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
 ) -> Bool {
     let options = HoneycombReactNative.optionsBuilder()
-        .setApiKey("test-key")
+        .setAPIKey("test-key")
         .setServiceName("your-great-react-native-app")
-        .setDebug(true)
     HoneycombReactNative.configure(options)
     //...
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The IOS docs used `setApiKey` when the method name is `setAPIKey`
Android did not include `android-agent` dependencies. 

- Closes #<enter issue here>

## Short description of the changes

Added missing dependency and fix typo.

## How to verify that this has the expected result

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation