### PR TITLE
fix: Make os.name consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v.Next
 
 - docs: Native Module documentation updated to include important configuration steps.
+- fix: OS name capitalization are now consistent across modules and JS.
 
 ## v0.5.0
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -46,7 +46,7 @@ setup_file() {
   assert_not_empty "$(resource_attribute_named 'telemetry.distro.version' 'string')"
   assert_equal "$(resource_attribute_named 'telemetry.sdk.language' 'string' | uniq)" '"hermesjs"'
 
-  assert_equal_or "$(resource_attribute_named 'os.name' 'string' | awk '{print tolower($0)}' | uniq)" '"android"' '"ios"'
+  assert_equal_or "$(resource_attribute_named 'os.name' 'string' | uniq)" '"Android"' '"iOS"'
 
   assert_not_empty "$(resource_attribute_named 'os.version' 'string')"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,7 @@ import {
   ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions/incubating';
 import { VERSION } from './version';
-import { Platform } from 'react-native';
+import { Platform, type PlatformOSType } from 'react-native';
 import {
   SlowEventLoopInstrumentation,
   type SlowEventLoopInstrumentationConfig,
@@ -61,6 +61,19 @@ interface HoneycombReactNativeOptions extends Partial<HoneycombOptions> {
   uncaughtExceptionInstrumentationConfig?: UncaughtExceptionInstrumentationConfig;
   fetchInstrumentationConfig?: FetchInstrumentationConfig;
   slowEventLoopInstrumentationConfig?: SlowEventLoopInstrumentationConfig;
+}
+
+const reactNativeOSTypeToOtelOSName: Record<PlatformOSType, string> = {
+  ios: 'iOS',
+  android: 'Android',
+  macos: 'macOS',
+  native: 'Native',
+  web: 'Web',
+  windows: 'windows',
+};
+
+function getOSName(): string {
+  return reactNativeOSTypeToOtelOSName[Platform.OS];
 }
 
 /**
@@ -97,10 +110,10 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
       [ATTR_TELEMETRY_SDK_VERSION]: VERSION,
 
       // OS attributes
-      [ATTR_OS_NAME]: Platform.OS,
+      [ATTR_OS_NAME]: getOSName(),
       [ATTR_OS_VERSION]: Platform.Version,
-      [ATTR_OS_DESCRIPTION]: Platform.OS,
-      [ATTR_OS_TYPE]: Platform.OS,
+      [ATTR_OS_DESCRIPTION]: getOSName(),
+      [ATTR_OS_TYPE]: getOSName(),
 
       // Stubbed out attributes
       [ATTR_DEVICE_ID]: '',


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
depending on where a span originated (JS or Native) the os name would have different spelling. 

- Closes #<enter issue here>

## Short description of the changes
Updated the resource attributes on JS layer to be consistent with the native modules.

## How to verify that this has the expected result

Smoke tests have been updated and will fail if any operating system name is inconsistent.

---

- [X] CHANGELOG is updated
- [N/A] README is updated with documentation