### PR TITLE
feat: Add expo plugin to generate source map UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - maint: Update Swift SDK from 0.0.16 to 2.1.0
 - docs: Native Module documentation updated to include important configuration steps.
 - fix: OS name capitalization are now consistent across modules and JS.
+- feat: Adds an expo plugin which inserts embeds a unique build id to be used for source map symbolication
 
 ## v0.5.0
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,40 @@ override func application(
 
 Refer to our [Honeycomb documentation](https://docs.honeycomb.io/get-started/start-building/web/) for more information on instrumentation and troubleshooting.
 
+## Source Map Symbolication
+React Native projects automatically minify JS source files. Honeycomb provides a collector that can un-minify JS stack traces, but that requires a little bit of set up.
+
+### Generating Source Maps
+
+iOS projects have source maps [disabled by default](https://reactnative.dev/docs/debugging-release-builds). To generate source maps during a build, open Xcode and edit the build phase "Bundle React Native code and images". Add this line to the top of the script:
+
+```
+export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";
+```
+
+Android projects will generate source maps by default.
+
+### Tracking Source Maps
+
+Once you have your source maps, your app will need to include an attribute on the telemetry it emits so that we know which source map should be used for which stack trace.
+
+For expo projects, add the following to your `app.json` or `app.config.js`:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      // ...
+      ["@honeycombio/opentelemetry-react-native"],
+    ]
+  }
+}
+```
+
+### Tying It All Together
+(this section coming soon)
+
+
 ## SDK Configuration Options
 
 See the [Honeycomb Web SDK](https://github.com/honeycombio/honeycomb-opentelemetry-web/tree/main/packages/honeycomb-opentelemetry-web) for more most options.

--- a/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
+++ b/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
@@ -2,6 +2,7 @@ package com.honeycombopentelemetryreactnative
 
 import android.app.Application
 import android.content.Context
+import android.content.pm.PackageManager
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModule
@@ -24,10 +25,15 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
     return HoneycombOpentelemetryReactNativeModule.otelRum?.rumSessionId
   }
 
+  override fun getDebugSourceMapUUID(): String? {
+    return HoneycombOpentelemetryReactNativeModule.sourceMapUuid
+  }
+
   companion object {
     const val NAME = "HoneycombOpentelemetryReactNative"
 
     private var otelRum : OpenTelemetryRum? = null
+    private var sourceMapUuid: String? = null
 
     fun optionsBuilder(context: Context): HoneycombOptions.Builder {
         return HoneycombOptions.builder(context)
@@ -38,6 +44,17 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
     }
 
     fun configure(app: Application, builder: HoneycombOptions.Builder) {
+      val packageManager = app.packageManager
+      val applicationInfo =
+        packageManager.getApplicationInfo(
+          app.packageName,
+          PackageManager.GET_META_DATA,
+        )
+      sourceMapUuid = applicationInfo.metaData?.getString("app.debug.source_map_uuid")
+
+      if (sourceMapUuid != null) {
+        builder.setResourceAttributes(mapOf("app.debug.source_map_uuid" to sourceMapUuid as String))
+      }
 
       val options = builder.build()
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/commonjs/plugin/withUUIDplugin');

--- a/ios/HoneycombOpentelemetryReactNative.mm
+++ b/ios/HoneycombOpentelemetryReactNative.mm
@@ -13,4 +13,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getSessionId) {
   return [HNYReactNativeWrapper sessionId];
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getDebugSourceMapUUID) {
+  return [HNYReactNativeWrapper debugSourceMapUUID];
+}
+
 @end

--- a/ios/HoneycombReactNative.swift
+++ b/ios/HoneycombReactNative.swift
@@ -1,7 +1,6 @@
 import Honeycomb
 
 @objc(HNYReactNativeWrapper) public class HoneycombReactNative: NSObject {
-
     @objc public static func optionsBuilder() -> HoneycombOptions.Builder {
         return HoneycombOptions.Builder()
             // This produces a lot of extra UI events that are not particularly helpful
@@ -13,6 +12,12 @@ import Honeycomb
 
     @objc public static func configure(_ configure: HoneycombOptions.Builder) {
         do {
+            if let sourceMapUuid = Bundle.main.object(
+                forInfoDictionaryKey: "app.debug.source_map_uuid"
+            ) as? String {
+                configure.setResourceAttributes(["app.debug.source_map_uuid": sourceMapUuid])
+            }
+
             try Honeycomb.configure(options: configure.build())
         } catch {
             NSException(name: NSExceptionName("HoneycombOptionsError"), reason: "\(error)").raise()
@@ -21,5 +26,9 @@ import Honeycomb
 
     @objc public static func sessionId() -> String? {
         return Honeycomb.currentSession()?.id
+    }
+
+    @objc public static func debugSourceMapUUID() -> String? {
+        return Bundle.main.object(forInfoDictionaryKey: "app.debug.source_map_uuid") as? String
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "default": "./lib/commonjs/index.js"
       }
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./app.plugin.js": "./app.plugin.js"
   },
   "files": [
     "src",
@@ -24,6 +25,7 @@
     "android",
     "ios",
     "cpp",
+    "app.plugin.js",
     "*.podspec",
     "react-native.config.js",
     "!ios/build",
@@ -68,6 +70,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^19.6.0",
     "@evilmartians/lefthook": "^1.5.0",
+    "@expo/config-plugins": "^11.0.7",
     "@react-native-community/cli": "15.0.1",
     "@react-native/eslint-config": "^0.73.1",
     "@react-navigation/native": "7.1.9",
@@ -89,6 +92,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
+    "@expo/config-plugins": "*",
     "expo-router": "*",
     "react": "*",
     "react-native": "*"

--- a/src/NativeHoneycombOpentelemetryReactNative.ts
+++ b/src/NativeHoneycombOpentelemetryReactNative.ts
@@ -3,6 +3,7 @@ import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
   getSessionId(): string | null;
+  getDebugSourceMapUUID(): string | null;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import {
 } from './UncaughtExceptionInstrumentation';
 import {
   resourceFromAttributes,
+  type DetectedResourceAttributes,
   type Resource,
 } from '@opentelemetry/resources';
 import { RandomIdGenerator } from '@opentelemetry/sdk-trace-base';
@@ -107,8 +108,8 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
       );
     }
 
-    let resource: Resource = resourceFromAttributes({
-      // Honeycomb distro attributes
+    const attributes: DetectedResourceAttributes = {
+      // Honeycomb distro attributes,
       'honeycomb.distro.version': VERSION,
       'honeycomb.distro.runtime_version': 'react native',
 
@@ -131,7 +132,13 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
       [ATTR_DEVICE_MODEL_IDENTIFIER]: '',
       [ATTR_DEVICE_MODEL_NAME]: '',
       'rum.sdk.version': '',
-    });
+    };
+    const sourceMapUuid =
+      HoneycombOpentelemetryReactNative.getDebugSourceMapUUID();
+    if (sourceMapUuid) {
+      attributes['app.debug.source_map_uuid'] = sourceMapUuid;
+    }
+    let resource: Resource = resourceFromAttributes(attributes);
 
     if (options?.resource) {
       resource = resource.merge(options.resource);

--- a/src/plugin/withUUIDAndroidPlugin.ts
+++ b/src/plugin/withUUIDAndroidPlugin.ts
@@ -1,0 +1,39 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withAndroidManifest } from '@expo/config-plugins';
+
+interface AndroidPluginOptions {
+  sourceMapUuid: string;
+}
+
+const withAndroidPlugin: ConfigPlugin<AndroidPluginOptions> = (
+  config,
+  options
+) => {
+  return withAndroidManifest(config, (config) => {
+    const mainApplication = config?.modResults?.manifest?.application?.[0];
+
+    if (mainApplication) {
+      // Ensure meta-data array exists
+      if (!mainApplication['meta-data']) {
+        mainApplication['meta-data'] = [];
+      }
+
+      // Remove any existing entry with the same name
+      mainApplication['meta-data'] = mainApplication['meta-data'].filter(
+        (entry) => entry.$['android:name'] !== 'app.debug.source_map_uuid'
+      );
+
+      // Add the custom message as a meta-data entry
+      mainApplication['meta-data'].push({
+        $: {
+          'android:name': 'app.debug.source_map_uuid',
+          'android:value': options.sourceMapUuid,
+        },
+      });
+    }
+
+    return config;
+  });
+};
+
+export default withAndroidPlugin;

--- a/src/plugin/withUUIDIosPlugin.ts
+++ b/src/plugin/withUUIDIosPlugin.ts
@@ -7,7 +7,7 @@ interface IOSPluginOptions {
 
 const withIOSPlugin: ConfigPlugin<IOSPluginOptions> = (config, options) => {
   return withInfoPlist(config, (config) => {
-    config.modResults.appDebugSourceMapUUID = options.sourceMapUuid;
+    config.modResults['app.debug.source_map_uuid'] = options.sourceMapUuid;
     return config;
   });
 };

--- a/src/plugin/withUUIDIosPlugin.ts
+++ b/src/plugin/withUUIDIosPlugin.ts
@@ -1,0 +1,15 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withInfoPlist } from '@expo/config-plugins';
+
+interface IOSPluginOptions {
+  sourceMapUuid: string;
+}
+
+const withIOSPlugin: ConfigPlugin<IOSPluginOptions> = (config, options) => {
+  return withInfoPlist(config, (config) => {
+    config.modResults.appDebugSourceMapUUID = options.sourceMapUuid;
+    return config;
+  });
+};
+
+export default withIOSPlugin;

--- a/src/plugin/withUUIDPlugin.ts
+++ b/src/plugin/withUUIDPlugin.ts
@@ -1,0 +1,22 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+
+import fs from 'node:fs';
+import withAndroidPlugin from './withUUIDAndroidPlugin';
+import withIOSPlugin from './withUUIDIosPlugin';
+
+const withPlugin: ConfigPlugin = (config) => {
+  const sourceMapUuid = crypto.randomUUID();
+  // Apply Android modifications first
+  config = withAndroidPlugin(config, { sourceMapUuid });
+  // Then apply iOS modifications and return
+  const resultConfig = withIOSPlugin(config, { sourceMapUuid });
+
+  if (!fs.existsSync('./dist/tmp/hny')) {
+    fs.mkdirSync('./dist/tmp/hny', { recursive: true });
+  }
+  fs.writeFileSync('./dist/tmp/hny/SourceMapUuid.txt', sourceMapUuid);
+
+  return resultConfig;
+};
+
+export default withPlugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:~7.10.4":
+  version: 7.10.4
+  resolution: "@babel/code-frame@npm:7.10.4"
+  dependencies:
+    "@babel/highlight": "npm:^7.10.4"
+  checksum: 10/4ef9c679515be9cb8eab519fcded953f86226155a599cf7ea209e40e088bb9a51bb5893d3307eae510b07bb3e359d64f2620957a00c27825dbe26ac62aca81f5
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.26.8":
   version: 7.26.8
   resolution: "@babel/compat-data@npm:7.26.8"
@@ -274,6 +283,18 @@ __metadata:
     "@babel/template": "npm:^7.27.0"
     "@babel/types": "npm:^7.27.0"
   checksum: 10/0dd40ba1e5ba4b72d1763bb381384585a56f21a61a19dc1b9a03381fe8e840207fdaa4da645d14dc028ad768087d41aad46347cc6573bd69d82f597f5a12dc6f
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.10.4":
+  version: 7.25.9
+  resolution: "@babel/highlight@npm:7.25.9"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+    chalk: "npm:^2.4.2"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.0.0"
+  checksum: 10/0d165283dd4eb312292cea8fec3ae0d376874b1885f476014f0136784ed5b564b2c2ba2d270587ed546ee92505056dab56493f7960c01c4e6394d71d1b2e7db6
   languageName: node
   linkType: hard
 
@@ -1804,6 +1825,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/config-plugins@npm:^11.0.7":
+  version: 11.0.7
+  resolution: "@expo/config-plugins@npm:11.0.7"
+  dependencies:
+    "@expo/config-types": "npm:^54.0.7"
+    "@expo/json-file": "npm:~10.0.6"
+    "@expo/plist": "npm:^0.4.6"
+    "@expo/sdk-runtime-versions": "npm:^1.0.0"
+    chalk: "npm:^4.1.2"
+    debug: "npm:^4.3.5"
+    getenv: "npm:^2.0.0"
+    glob: "npm:^10.4.2"
+    resolve-from: "npm:^5.0.0"
+    semver: "npm:^7.5.4"
+    slash: "npm:^3.0.0"
+    slugify: "npm:^1.6.6"
+    xcode: "npm:^3.0.1"
+    xml2js: "npm:0.6.0"
+  checksum: 10/09055417e8b758dd05dc1dbfda7f8651f9fe653a78ea6f0589d2ed068f04385848cf8447e10bdd1d9ff2cf3e16ee4c19bf9994dcf11f707a152014da8922b6a1
+  languageName: node
+  linkType: hard
+
+"@expo/config-types@npm:^54.0.7":
+  version: 54.0.7
+  resolution: "@expo/config-types@npm:54.0.7"
+  checksum: 10/fbd4f9ecc69f31ba60c54f63d0129f6715700c18b1610e8ef157910045bb63d99941d54f0db523244d5603e79c38ad8ebb678aaaadbfb5c75d7296592b95885c
+  languageName: node
+  linkType: hard
+
+"@expo/json-file@npm:~10.0.6":
+  version: 10.0.6
+  resolution: "@expo/json-file@npm:10.0.6"
+  dependencies:
+    "@babel/code-frame": "npm:~7.10.4"
+    json5: "npm:^2.2.3"
+  checksum: 10/b1fd9af5ed2ee6f4e3b52df3f62edc59843b342fe7501d4d3eb7cfb651e867c285e58a03bd6201b0dec782e78728f0a640b9040832b385cb2f4e45f0f4b5bc1d
+  languageName: node
+  linkType: hard
+
+"@expo/plist@npm:^0.4.6":
+  version: 0.4.6
+  resolution: "@expo/plist@npm:0.4.6"
+  dependencies:
+    "@xmldom/xmldom": "npm:^0.8.8"
+    base64-js: "npm:^1.2.3"
+    xmlbuilder: "npm:^15.1.1"
+  checksum: 10/7e0e1ab13a27dbd332fdb0787cd72d5ecab8b76fb0c657762504502420433d9eebbfe03d53013b2c29bb25f8b6f76dd1bb07feb3274adb54454e3fe2f33fbd79
+  languageName: node
+  linkType: hard
+
+"@expo/sdk-runtime-versions@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@expo/sdk-runtime-versions@npm:1.0.0"
+  checksum: 10/0942d5a356f590e8dc795761456cc48b3e2d6a38ad2a02d6774efcdc5a70424e05623b4e3e5d2fec0cdc30f40dde05c14391c781607eed3971bf8676518bfd9d
+  languageName: node
+  linkType: hard
+
 "@flatten-js/interval-tree@npm:^1.1.2":
   version: 1.1.3
   resolution: "@flatten-js/interval-tree@npm:1.1.3"
@@ -1833,6 +1911,7 @@ __metadata:
   dependencies:
     "@commitlint/config-conventional": "npm:^19.6.0"
     "@evilmartians/lefthook": "npm:^1.5.0"
+    "@expo/config-plugins": "npm:^11.0.7"
     "@honeycombio/opentelemetry-web": "npm:^1.0.2"
     "@opentelemetry/instrumentation": "npm:^0.203.0"
     "@opentelemetry/instrumentation-fetch": "npm:^0.203.0"
@@ -1858,6 +1937,7 @@ __metadata:
     turbo: "npm:^1.10.7"
     typescript: "npm:^5.2.2"
   peerDependencies:
+    "@expo/config-plugins": "*"
     expo-router: "*"
     react: "*"
     react-native: "*"
@@ -3890,6 +3970,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmldom/xmldom@npm:^0.8.8":
+  version: 0.8.11
+  resolution: "@xmldom/xmldom@npm:0.8.11"
+  checksum: 10/f6d6ffdf71cf19d9b3c10e978fad40d2f85453bf5b2aa05be8aa0c5ad13f84690c3153316729213cc652d06ec12c605ddb0aa03886f1d73d51b974b4105d31e3
+  languageName: node
+  linkType: hard
+
 "JSONStream@npm:^1.3.5":
   version: 1.3.5
   resolution: "JSONStream@npm:1.3.5"
@@ -4070,7 +4157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.2.0":
+"ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
   dependencies:
@@ -4480,7 +4567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
+"base64-js@npm:^1.2.3, base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10/669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -4498,6 +4585,13 @@ __metadata:
   version: 2.2.3
   resolution: "before-after-hook@npm:2.2.3"
   checksum: 10/e676f769dbc4abcf4b3317db2fd2badb4a92c0710e0a7da12cf14b59c3482d4febf835ad7de7874499060fd4e13adf0191628e504728b3c5bb4ec7a878c09940
+  languageName: node
+  linkType: hard
+
+"big-integer@npm:1.6.x":
+  version: 1.6.52
+  resolution: "big-integer@npm:1.6.52"
+  checksum: 10/4bc6ae152a96edc9f95020f5fc66b13d26a9ad9a021225a9f0213f7e3dc44269f423aa8c42e19d6ac4a63bb2b22140b95d10be8f9ca7a6d9aa1b22b330d1f514
   languageName: node
   linkType: hard
 
@@ -4532,6 +4626,24 @@ __metadata:
     widest-line: "npm:^5.0.0"
     wrap-ansi: "npm:^9.0.0"
   checksum: 10/30e2804c3b8d86735817e25961b7861dbfb19adfdc0cf2a0afd8a6dc2e7114de636f86239f4069f81349449d16da3fb33c4100422f41931982bd7d247092a78e
+  languageName: node
+  linkType: hard
+
+"bplist-creator@npm:0.1.1":
+  version: 0.1.1
+  resolution: "bplist-creator@npm:0.1.1"
+  dependencies:
+    stream-buffers: "npm:2.2.x"
+  checksum: 10/4f185ee84a97f4b7c7caa73436b9c664e410f8640661a4ae97f0fbe1420aa8fc5db39d9a9d8571c87069665f6d3c5a8a8d2be30db7b64681b7cc366695211913
+  languageName: node
+  linkType: hard
+
+"bplist-parser@npm:0.3.2":
+  version: 0.3.2
+  resolution: "bplist-parser@npm:0.3.2"
+  dependencies:
+    big-integer: "npm:1.6.x"
+  checksum: 10/6edf4354c32f5661c258422e478be0f5c6a779bb87c2ae15ee92dd1c046368decbff8a28c86c558a3b7007e1381b91d5eed1c4c8e83e86405197777d944abaa8
   languageName: node
   linkType: hard
 
@@ -4842,6 +4954,17 @@ __metadata:
   version: 5.4.1
   resolution: "chalk@npm:5.4.1"
   checksum: 10/29df3ffcdf25656fed6e95962e2ef86d14dfe03cd50e7074b06bad9ffbbf6089adbb40f75c00744d843685c8d008adaf3aed31476780312553caf07fa86e5bc7
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "chalk@npm:2.4.2"
+  dependencies:
+    ansi-styles: "npm:^3.2.1"
+    escape-string-regexp: "npm:^1.0.5"
+    supports-color: "npm:^5.3.0"
+  checksum: 10/3d1d103433166f6bfe82ac75724951b33769675252d8417317363ef9d54699b7c3b2d46671b772b893a8e50c3ece70c4b933c73c01e81bc60ea4df9b55afa303
   languageName: node
   linkType: hard
 
@@ -7224,6 +7347,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"getenv@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "getenv@npm:2.0.0"
+  checksum: 10/ba25153e26c0960199b5de1a0c7bdfc661226c00e27bb194f829ed129843510ce230f9daa3b4d06f10056298a9c4e9afbbd358fc7632a545f299e370772b047a
+  languageName: node
+  linkType: hard
+
 "git-raw-commits@npm:^4.0.0":
   version: 4.0.0
   resolution: "git-raw-commits@npm:4.0.0"
@@ -7298,7 +7428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2":
+"glob@npm:^10.2.2, glob@npm:^10.4.2":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:
@@ -7499,6 +7629,13 @@ __metadata:
   version: 1.1.0
   resolution: "has-bigints@npm:1.1.0"
   checksum: 10/90fb1b24d40d2472bcd1c8bd9dd479037ec240215869bdbff97b2be83acef57d28f7e96bdd003a21bed218d058b49097f4acc8821c05b1629cc5d48dd7bfcccd
+  languageName: node
+  linkType: hard
+
+"has-flag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "has-flag@npm:3.0.0"
+  checksum: 10/4a15638b454bf086c8148979aae044dd6e39d63904cd452d970374fa6a87623423da485dfb814e7be882e05c096a7ccf1ebd48e7e7501d0208d8384ff4dea73b
   languageName: node
   linkType: hard
 
@@ -11583,6 +11720,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plist@npm:^3.0.5":
+  version: 3.1.0
+  resolution: "plist@npm:3.1.0"
+  dependencies:
+    "@xmldom/xmldom": "npm:^0.8.8"
+    base64-js: "npm:^1.5.1"
+    xmlbuilder: "npm:^15.1.1"
+  checksum: 10/f513beecc01a021b4913d4e5816894580b284335ae437e7ed2d5e78f8b6f0d2e0f874ec57bab9c9d424cc49e77b8347efa75abcfa8ac138dbfb63a045e1ce559
+  languageName: node
+  linkType: hard
+
 "pngjs@npm:^7.0.0":
   version: 7.0.0
   resolution: "pngjs@npm:7.0.0"
@@ -12619,6 +12767,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:>=0.6.0":
+  version: 1.4.1
+  resolution: "sax@npm:1.4.1"
+  checksum: 10/b1c784b545019187b53a0c28edb4f6314951c971e2963a69739c6ce222bfbc767e54d320e689352daba79b7d5e06d22b5d7113b99336219d6e93718e2f99d335
+  languageName: node
+  linkType: hard
+
 "scheduler@npm:0.25.0":
   version: 0.25.0
   resolution: "scheduler@npm:0.25.0"
@@ -12886,6 +13041,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-plist@npm:^1.1.0":
+  version: 1.4.0
+  resolution: "simple-plist@npm:1.4.0"
+  dependencies:
+    bplist-creator: "npm:0.1.1"
+    bplist-parser: "npm:0.3.2"
+    plist: "npm:^3.0.5"
+  checksum: 10/e03f1619370d8d502543f2f9c6448722456dd2594e34d689eb8706c7c9e328c1ed5bef89280cb9e13426942ec1ab0f5655406ab70550be28b84fcccc304d447b
+  languageName: node
+  linkType: hard
+
 "simple-swizzle@npm:^0.2.2":
   version: 0.2.2
   resolution: "simple-swizzle@npm:0.2.2"
@@ -12931,6 +13097,13 @@ __metadata:
     astral-regex: "npm:^1.0.0"
     is-fullwidth-code-point: "npm:^2.0.0"
   checksum: 10/4e82995aa59cef7eb03ef232d73c2239a15efa0ace87a01f3012ebb942e963fbb05d448ce7391efcd52ab9c32724164aba2086f5143e0445c969221dde3b6b1e
+  languageName: node
+  linkType: hard
+
+"slugify@npm:^1.6.6":
+  version: 1.6.6
+  resolution: "slugify@npm:1.6.6"
+  checksum: 10/d0737cdedc834c50f74227bc1a1cf4f449f3575893f031b0e8c59f501c73526c866a23e47261b262c7acdaaaaf30d6f9e8aaae22772b3f56e858ac84c35efa7b
   languageName: node
   linkType: hard
 
@@ -13117,6 +13290,13 @@ __metadata:
   version: 0.2.2
   resolution: "stdin-discarder@npm:0.2.2"
   checksum: 10/642ffd05bd5b100819d6b24a613d83c6e3857c6de74eb02fc51506fa61dc1b0034665163831873868157c4538d71e31762bcf319be86cea04c3aba5336470478
+  languageName: node
+  linkType: hard
+
+"stream-buffers@npm:2.2.x":
+  version: 2.2.0
+  resolution: "stream-buffers@npm:2.2.0"
+  checksum: 10/79f897cead810383b4181e4ee56f4855a69b51c9da4c96b91ccca6ee6fe90b908bea9b304225bedd1a5e2c41d72bc88d3ada7f897b51f8ffae3593f7460ecbc8
   languageName: node
   linkType: hard
 
@@ -13369,6 +13549,15 @@ __metadata:
   version: 9.2.1
   resolution: "sudo-prompt@npm:9.2.1"
   checksum: 10/0557d0eecebf8db8212df4a9816509c875ca65ad9ee26a55240848820f9bdbdbbd9e5a1bdb5aa052fb1f748cba4ef90c8da9b40628f59e6dc79ca986e80740de
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^5.3.0":
+  version: 5.5.0
+  resolution: "supports-color@npm:5.5.0"
+  dependencies:
+    has-flag: "npm:^3.0.0"
+  checksum: 10/5f505c6fa3c6e05873b43af096ddeb22159831597649881aeb8572d6fe3b81e798cc10840d0c9735e0026b250368851b7f77b65e84f4e4daa820a4f69947f55b
   languageName: node
   linkType: hard
 
@@ -14077,6 +14266,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "uuid@npm:7.0.3"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10/b2a4d30ecd6581015175487426558aafd7f7b4013a2e30802c128cc28cad9abe46ecd36c02f7fbcde7908fd4672334818d56a441c0871963d6bd89d911bef2ea
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -14441,10 +14639,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xcode@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "xcode@npm:3.0.1"
+  dependencies:
+    simple-plist: "npm:^1.1.0"
+    uuid: "npm:^7.0.3"
+  checksum: 10/539d7b808ccce648078c5ceb63c4f9c14a7018a7db688fe0ff55c7d59e685c67392f18e9f531ce524f8d71162e836714b8835fa0a8688e976d4a293b147917c3
+  languageName: node
+  linkType: hard
+
 "xdg-basedir@npm:^5.1.0":
   version: 5.1.0
   resolution: "xdg-basedir@npm:5.1.0"
   checksum: 10/b60e8a2c663ccb1dac77c2d913f3b96de48dafbfa083657171d3d50e10820b8a04bb4edfe9f00808c8c20e5f5355e1927bea9029f03136e29265cb98291e1fea
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:0.6.0":
+  version: 0.6.0
+  resolution: "xml2js@npm:0.6.0"
+  dependencies:
+    sax: "npm:>=0.6.0"
+    xmlbuilder: "npm:~11.0.0"
+  checksum: 10/717f44ceef3f749ac21b381f829ba6525eec78cb9a53638046739565900e505a8e8caa62a6850b0a94cfe57ebe1a29b5367d55c4f642a3d640b9f69ca1fc7c8c
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:^15.1.1":
+  version: 15.1.1
+  resolution: "xmlbuilder@npm:15.1.1"
+  checksum: 10/e6f4bab2504afdd5f80491bda948894d2146756532521dbe7db33ae0931cd3000e3b4da19b3f5b3f51bedbd9ee06582144d28136d68bd1df96579ecf4d4404a2
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 10/c8c3d208783718db5b285101a736cd8e6b69a5c265199a0739abaa93d1a1b7de5489fd16df4e776e18b2c98cb91f421a7349e99fd8c1ebeb44ecfed72a25091a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Which problem is this PR solving?
we need to link source maps to a specific build

## Short description of the changes
The plugin:
- generates a uuid
- writes it into the `manifest.xml` / `info.plist`
- writes that uuid into a file on the filesystem (in `$cwd/dist/tmp/hny/SourceMapUuid.txt`
    - future PRs/guidance will use this uuid when uploading the source maps, similar to how we implemented proguard uploads on Android

This PR also adds code to our native bridges to read that value and attach it as a resource attribute.

### Usage
Add the following line to the plugins section of `app.json`/`app.config.ts`:

```js
{
  "expo": {
    "plugins": [
      // ...
      ["@honeycombio/opentelemetry-react-native"],
    ],
  }
}
```

## How to verify that this has the expected result
I added this library to our internal react native app and verified the source map attribute appeared in our telemetry.

---

- [ ] CHANGELOG is updated
- [ ] README is updated with documentation