### PR TITLE
feat: update event name from 'app start' to 'react native startup'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Honeycomb React Native SDK Changelog
 
 ## v.Next
+- Update `app startup` event name to `react native startup`
 
 ## v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ You can disable them by using the following configuration options:
 
 | Option                                                | Type                                   | Required? | default value     | Description                                              |
 |-------------------------------------------------------|----------------------------------------|-----------|-------------------|----------------------------------------------------------|
-| `reactNativetartupInstrumentationConfig`              | UncaughtExceptionInstrumentationConfig | No        | { enabled: true } | configuration for React Native startup instrumentation   |
+| `reactNativeStartupInstrumentationConfig`              | UncaughtExceptionInstrumentationConfig | No        | { enabled: true } | configuration for React Native startup instrumentation   |
 | `uncaughtExceptionInstrumentationConfig`              | UncaughtExceptionInstrumentationConfig | No        | { enabled: true } | configuration for uncaught exception instrumentation     |
 | `fetchInstrumentationConfig`                          | FetchInstrumentationConfig             | No        | { enabled: true } | configuration for fetch instrumentation.                 |
 | `slowEventLoopInstrumentationConfig`                  | slowEventLoopInstrumentationConfig     | No        | { enabled: true } | configuration for slow event loop instrumentation        |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ override fun onCreate() {
 
 6. iOS (optional)
 
-  a. Edit your app's podfile to add the `use_frameworks!` option. 
+  a. Edit your app's podfile to add the `use_frameworks!` option.
 
 `ios/Podfile`
 ```diff
@@ -168,24 +168,24 @@ You can disable them by using the following configuration options:
 
 | Option                                                | Type                                   | Required? | default value     | Description                                              |
 |-------------------------------------------------------|----------------------------------------|-----------|-------------------|----------------------------------------------------------|
-| `appStartupInstrumentationConfig`                     | UncaughtExceptionInstrumentationConfig | No        | { enabled: true } | configuration for app startup instrumentation            |
+| `reactNativetartupInstrumentationConfig`              | UncaughtExceptionInstrumentationConfig | No        | { enabled: true } | configuration for React Native startup instrumentation   |
 | `uncaughtExceptionInstrumentationConfig`              | UncaughtExceptionInstrumentationConfig | No        | { enabled: true } | configuration for uncaught exception instrumentation     |
 | `fetchInstrumentationConfig`                          | FetchInstrumentationConfig             | No        | { enabled: true } | configuration for fetch instrumentation.                 |
 | `slowEventLoopInstrumentationConfig`                  | slowEventLoopInstrumentationConfig     | No        | { enabled: true } | configuration for slow event loop instrumentation        |
 
-### App startup
-App startup instrumentation automatically measures the time from when the native SDKs start to when
+### React Native Startup
+React Native Startup instrumentation automatically measures the time from when the native SDKs start to when
 native code starts running to when the JavaScript SDK is finished initializing. This
 instrumentation requires the Honeycomb native SDKs to be installed to measure the full span. The
-emitted span is named `app start`.
+emitted span is named `react native startup`.
 
 ### Error handler
 The Honeycomb React Native SDK includes a global error handler for uncaught exceptions by default.
 
 ### Slow event loop detection
-The Honeycomb React Native SDK comes with a slow event loop detection instrumentation. 
+The Honeycomb React Native SDK comes with a slow event loop detection instrumentation.
 
-#### Configuration 
+#### Configuration
 | Option                        | Type                                | Required? | default value | Description                                                                                                                                                                         |
 |-------------------------------|-------------------------------------|-----------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `loopSampleIntervalMs`.       | number                              | No        | 50            | Duration (in milliseconds) between each sampling of the event loop duration.                                                                                                        |
@@ -203,7 +203,7 @@ When a slow event loop is detected, it will emit a 'slow event loop' span with t
 ## Manual Instrumentation
 
 ### Navigation
-Navigation instrumentation depends on if you are using React NativeRouter or Expo Router for navigation. 
+Navigation instrumentation depends on if you are using React NativeRouter or Expo Router for navigation.
 Honeycomb SDK provides a component (`<NavigationInstrumentation>`) that you can place in your main app or layout file. Below are examples
 on using it with both ReactNative Router.
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.78.1):
     - hermes-engine/Pre-built (= 0.78.1)
   - hermes-engine/Pre-built (0.78.1)
-  - HoneycombOpentelemetryReactNative (0.5.0):
+  - HoneycombOpentelemetryReactNative (0.6.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1886,7 +1886,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: f493b0a600aed5dc06532141603688a30a5b2f61
-  HoneycombOpentelemetryReactNative: c46cb3661a3e2150050baa6ed9ff25415a3154d4
+  HoneycombOpentelemetryReactNative: 01a154a8342d3ec02dd9e6286ab1cb883a6ea024
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 082fbc90409015eac1366795a0b90f8b5cb28efe
   RCTRequired: ca966f4da75b62ce3ea8c538d82cb5ecbb06f12a

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -130,9 +130,9 @@ EOF
   assert_equal "$result" '"http://localhost:1080/simple-api"'
 }
 
-@test "App start sends span" {
+@test "App start sends React Native Startup span" {
   result=$(span_names_for "@honeycombio/app-startup" | uniq)
-  assert_equal "$result" '"app start"'
+  assert_equal "$result" '"react native startup"'
 }
 
 @test "telemetry.sdk.language is correct for React Native (js) spans" {

--- a/src/ReactNativeStartupInstrumentation.tsx
+++ b/src/ReactNativeStartupInstrumentation.tsx
@@ -6,17 +6,19 @@ import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
 const LIBRARY_NAME = '@honeycombio/app-startup';
 
-export interface AppStartupInstrumentationConfig
+export interface ReactNativeStartupInstrumentationConfig
   extends InstrumentationConfig {}
 
 /**
  * Emit a span with the total time from when the app was started to when this was called.
  */
-export class AppStartupInstrumentation extends InstrumentationBase {
+export class ReactNativeStartupInstrumentation extends InstrumentationBase {
   private _isEnabled: boolean;
 
-  constructor({ enabled = true }: AppStartupInstrumentationConfig = {}) {
-    const config: AppStartupInstrumentationConfig = {
+  constructor({
+    enabled = true,
+  }: ReactNativeStartupInstrumentationConfig = {}) {
+    const config: ReactNativeStartupInstrumentationConfig = {
       enabled,
     };
     super(LIBRARY_NAME, VERSION, config);
@@ -52,6 +54,6 @@ export class AppStartupInstrumentation extends InstrumentationBase {
 
   sendAppStartTrace(): void {
     let startTime = HoneycombOpentelemetryReactNative.getAppStartTime();
-    this.tracer.startSpan('app start', { startTime }).end();
+    this.tracer.startSpan('react native startup', { startTime }).end();
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,9 +8,9 @@ import {
   type FetchInstrumentationConfig,
 } from '@opentelemetry/instrumentation-fetch';
 import {
-  AppStartupInstrumentation,
-  type AppStartupInstrumentationConfig,
-} from './AppStartupInstrumentation';
+  ReactNativeStartupInstrumentation,
+  type ReactNativeStartupInstrumentationConfig,
+} from './ReactNativeStartupInstrumentation';
 import {
   UncaughtExceptionInstrumentation,
   type UncaughtExceptionInstrumentationConfig,
@@ -38,7 +38,7 @@ import {
 import { type SessionProvider } from '@opentelemetry/web-common';
 
 export { NavigationInstrumentation } from './NavigationInstrumentation';
-export { AppStartupInstrumentation } from './AppStartupInstrumentation';
+export { ReactNativeStartupInstrumentation } from './ReactNativeStartupInstrumentation';
 export {
   SlowEventLoopInstrumentation,
   type SlowEventLoopInstrumentationConfig,
@@ -69,7 +69,7 @@ class SessionIdProvider implements SessionProvider {
  * The options used to configure the Honeycomb React Native SDK.
  */
 interface HoneycombReactNativeOptions extends Partial<HoneycombOptions> {
-  appStartupInstrumentationConfig?: AppStartupInstrumentationConfig;
+  reactNativeStartupInstrumentationConfig?: ReactNativeStartupInstrumentationConfig;
   uncaughtExceptionInstrumentationConfig?: UncaughtExceptionInstrumentationConfig;
   fetchInstrumentationConfig?: FetchInstrumentationConfig;
   slowEventLoopInstrumentationConfig?: SlowEventLoopInstrumentationConfig;
@@ -95,9 +95,11 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
   constructor(options?: HoneycombReactNativeOptions) {
     const instrumentations = [...(options?.instrumentations || [])];
 
-    if (options?.appStartupInstrumentationConfig?.enabled !== false) {
+    if (options?.reactNativeStartupInstrumentationConfig?.enabled !== false) {
       instrumentations.push(
-        new AppStartupInstrumentation(options?.appStartupInstrumentationConfig)
+        new ReactNativeStartupInstrumentation(
+          options?.reactNativeStartupInstrumentationConfig
+        )
       );
     }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Improves clarity of the startup instrumentation feature by renaming it from "app start" to "react native startup"

## Short description of the changes

This PR updates the event name and associated configuration/class names from "app start" to "react native startup" to better reflect that this instrumentation specifically measures React Native initialization time (from native SDK start to JavaScript SDK initialization), not general app startup.

Changes include:
- Renamed `AppStartupInstrumentation` class to `ReactNativeStartupInstrumentation`
- Updated configuration option from `appStartupInstrumentationConfig` to `reactNativeStartupInstrumentationConfig`
- Changed emitted span name from `app start` to `react native startup`
- Updated documentation in README.md to reflect new naming
- Updated smoke tests to verify new span name
- Updated CHANGELOG.md

## How to verify that this has the expected result

1. Run the example app
2. Verify that a span named `react native startup` is emitted (not `app start`)
3. Run smoke tests: `cd smoke-tests && bats smoke-e2e.bats`

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation