### PR TITLE
feat: add attributes for build enviornment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v.Next
 
+- feat: Allow differentiation of telemetry based on build type.
+
 ## v0.6.1
 
 - Update `app startup` event name to `react native startup`

--- a/README.md
+++ b/README.md
@@ -151,9 +151,13 @@ These are the React Native-specific options:
 |----------------------|--------------------------------|-----------|------------------------------|
 
 ## Default Attributes
-All spans will include the following attributes
+All spans  will include the following attributes:
 
-TODO
+| name                          | Native or JS | static? | description                                                                               | example        |
+|-------------------------------|--------------|---------|-------------------------------------------------------------------------------------------|----------------|
+| `deployment.environment.name` | JS only.     | static. | "development" when running in developer mode, "production" if this is a production build. | "development"  |
+
+
 
 ## Auto-instrumentation
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ These are the React Native-specific options:
 |----------------------|--------------------------------|-----------|------------------------------|
 
 ## Default Attributes
-All spans  will include the following attributes:
+All spans will include the following attributes:
 
 | name                          | Native or JS | static? | description                                                                               | example        |
 |-------------------------------|--------------|---------|-------------------------------------------------------------------------------------------|----------------|

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.78.1):
     - hermes-engine/Pre-built (= 0.78.1)
   - hermes-engine/Pre-built (0.78.1)
-  - HoneycombOpentelemetryReactNative (0.6.0):
+  - HoneycombOpentelemetryReactNative (0.6.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1886,7 +1886,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: f493b0a600aed5dc06532141603688a30a5b2f61
-  HoneycombOpentelemetryReactNative: 01a154a8342d3ec02dd9e6286ab1cb883a6ea024
+  HoneycombOpentelemetryReactNative: c10833e24eced0aba90247e06dc53482057671cf
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 082fbc90409015eac1366795a0b90f8b5cb28efe
   RCTRequired: ca966f4da75b62ce3ea8c538d82cb5ecbb06f12a

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -83,7 +83,7 @@ EOF
 
 @test "Resources attributes are correct value" {
 
-  assert_equal "$(resource_attribute_named 'deployment.environment.name' 'string')" '"development"'
+  assert_equal "$(resource_attribute_named 'deployment.environment.name' 'string' | uniq)" '"development"'
 
   assert_not_empty "$(resource_attribute_named 'honeycomb.distro.version' 'string')"
   assert_not_empty "$(resource_attribute_named 'honeycomb.distro.runtime_version' 'string' | uniq)"

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -29,6 +29,7 @@ IOS_RESOURCE_ATTR_LIST=$(cat <<'EOF'
 "app.bundle.version"
 "app.debug.binaryName"
 "app.debug.build_uuid"
+"deployment.environment.name"
 "device.id"
 "device.model.identifier"
 "honeycomb.distro.runtime_version"
@@ -56,6 +57,7 @@ EOF
   result=$(resource_attributes_received | jq '.key' | sort | uniq)
 
   ANDROID_RESOURCE_ATTR_LIST=$(cat <<'EOF'
+"deployment.environment.name"
 "device.id"
 "device.manufacturer"
 "device.model.identifier"
@@ -80,6 +82,9 @@ EOF
 }
 
 @test "Resources attributes are correct value" {
+
+  assert_equal "$(resource_attribute_named 'deployment.environment.name' 'string')" '"development"'
+
   assert_not_empty "$(resource_attribute_named 'honeycomb.distro.version' 'string')"
   assert_not_empty "$(resource_attribute_named 'honeycomb.distro.runtime_version' 'string' | uniq)"
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -151,7 +151,7 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
       // React Native enviornment
       [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: __DEV__
         ? 'development'
-        : 'produciton',
+        : 'production',
     };
     const sourceMapUuid =
       HoneycombOpentelemetryReactNative.getDebugSourceMapUUID();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ import {
   ATTR_TELEMETRY_SDK_LANGUAGE,
   ATTR_TELEMETRY_SDK_NAME,
   ATTR_TELEMETRY_SDK_VERSION,
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
 } from '@opentelemetry/semantic-conventions/incubating';
 import { VERSION } from './version';
 import {
@@ -146,6 +147,11 @@ export class HoneycombReactNativeSDK extends HoneycombWebSDK {
       [ATTR_TELEMETRY_SDK_LANGUAGE]: 'hermesjs',
       [ATTR_TELEMETRY_SDK_NAME]: 'opentelemetry',
       [ATTR_TELEMETRY_SDK_VERSION]: VERSION,
+
+      // React Native enviornment
+      [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: __DEV__
+        ? 'development'
+        : 'produciton',
     };
     const sourceMapUuid =
       HoneycombOpentelemetryReactNative.getDebugSourceMapUUID();


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
It is difficult to tell with JS exceptions if they are coming from a development or a production build. 

- Closes #<enter issue here>

## Short description of the changes
Add a resource attribute to all outgoing JS spans to indicate if this is `development` or `production` builds.

## How to verify that this has the expected result

Tests have been added to ensure this

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation