### PR TITLE
fix: remove spurious "address at" lines in android stack traces

### DIFF
--- a/src/UncaughtExceptionInstrumentation.ts
+++ b/src/UncaughtExceptionInstrumentation.ts
@@ -51,6 +51,9 @@ export class UncaughtExceptionInstrumentation extends InstrumentationBase {
             stack: caughtError.stack ?? '',
           };
 
+    // Remove the "address at" in Android stack traces that break parsing.
+    error.stack?.replace(/ at anonymous \(address at /g, ' at anonymous (');
+
     recordException(error, {}, this.tracer, this.applyCustomAttributesOnSpan);
 
     if (this._oldErrorHandler) {

--- a/src/UncaughtExceptionInstrumentation.ts
+++ b/src/UncaughtExceptionInstrumentation.ts
@@ -51,8 +51,8 @@ export class UncaughtExceptionInstrumentation extends InstrumentationBase {
             stack: caughtError.stack ?? '',
           };
 
-    // Remove the "address at" in Android stack traces that break parsing.
-    error.stack?.replace(/ at anonymous \(address at /g, ' at anonymous (');
+    // Remove the "address at" in stack traces that break parsing.
+    error.stack = error.stack?.replace(/ \(address at \/?/g, ' (/');
 
     recordException(error, {}, this.tracer, this.applyCustomAttributesOnSpan);
 


### PR DESCRIPTION
## Which problem is this PR solving?

This fixes an issue we've seen with some stack traces coming from Android React Native apps, where our client-side stacktrace parsing fails.

## Short description of the changes

We parse javascript stack traces on the client, but the parser we use was designed for browsers, and does not work with the exact format of stack traces we see from Android React Native. Until we move stack parsing to the backend, this change patches the stack traces so that our client side parser can parse them.

## How to verify that this has the expected result

I have verified this locally by running the app against a modified collector.

---

N/A ~- [ ] CHANGELOG is updated~
N/A ~- [ ] README is updated with documentation~