### PR TITLE
rel: prep for v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Honeycomb React Native SDK Changelog
 
+## v.Next
+
 ## v0.7.0
 
 - feat: Allow differentiation of telemetry based on build type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Honeycomb React Native SDK Changelog
 
-## v.Next
+## v0.7.0
 
 - feat: Allow differentiation of telemetry based on build type.
+- maint: Update Android SDK from 0.0.16 to 0.0.19
+- maint: Update Swift SDK from 2.1.0 to 2.1.2
 
 ## v0.6.1
 

--- a/HoneycombOpentelemetryReactNative.podspec
+++ b/HoneycombOpentelemetryReactNative.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   spm_dependency(s,
     url: 'https://github.com/honeycombio/honeycomb-opentelemetry-swift.git',
-    requirement: {kind: 'upToNextMajorVersion', minimumVersion: '2.1.0'},
+    requirement: {kind: 'upToNextMajorVersion', minimumVersion: '2.1.2'},
     products: ['Honeycomb']
   )
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sdk.start();
 ```Kotlin
 dependencies {
     //...
-    implementation "io.honeycomb.android:honeycomb-opentelemetry-android:0.0.16"
+    implementation "io.honeycomb.android:honeycomb-opentelemetry-android:0.0.19"
     implementation "io.opentelemetry.android:android-agent:0.11.0-alpha"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honeycombio/opentelemetry-react-native",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Honeycomb OpenTelemetry SDK for React Native Apps",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.6.1';
+export const VERSION = '0.7.0';


### PR DESCRIPTION
## Which problem is this PR solving?

Preparing release v0.7.0

## Short description of the changes

- feat: Allow differentiation of telemetry based on build type
- maint: Update Swift SDK from 2.1.0 to 2.1.2
- maint: Update Android SDK from 0.0.16 to 0.0.19

## How to verify that this has the expected result

All CI checks should pass

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation