### PR TITLE
docs: supported JS runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.Next
 
+- docs: Supported JS runtimes
 - docs: Add import information for Native Module configuration
 - docs: Add CLAUDE.md development guide for AI assistants
 - docs: Add MIGRATION.md guide and TROUBLESHOOTING.md for common issues

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ override func application(
 
 Refer to our [Honeycomb documentation](https://docs.honeycomb.io/get-started/start-building/web/) for more information on instrumentation and troubleshooting.
 
+> #### Other JS Runtimes
+> Honeycomb ReactNative SDK has been primarily designed for, and tested on Hermes (the default JS runtime for ReactNative).
+> Other Runtimes such as JavaScript Core have not been extensively tested. If you are using a different runtime, we highly 
+> encourage you to upgrade to Hermes.
+
 ## Source Map Symbolication
 React Native projects automatically minify JS source files. Honeycomb provides a collector that can un-minify JS stack traces, but that requires a little bit of set up.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We do not explicitly say in our Readme that we only officially support Hermes.

- Closes #<enter issue here>

## Short description of the changes

Added details about supporting Hermes and encouraging users of JS Core to upgrade.

## How to verify that this has the expected result

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation