### PR TITLE
fix: remove broken plugin code that writes a text file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## v.Next
 
+- fix: Remove `SourceMapUuid.txt` from UUID plugin, because it can be misleading
+
 ## v0.7.1
 
-- fix: Fix JavaScript stack trace parsing in Android.
+- fix: Fix JavaScript stack trace parsing in Android
 - docs: Supported JS runtimes
 - docs: Add import information for Native Module configuration
 - docs: Add CLAUDE.md development guide for AI assistants
@@ -13,7 +15,7 @@
 
 ## v0.7.0
 
-- feat: Allow differentiation of telemetry based on build type.
+- feat: Allow differentiation of telemetry based on build type
 - maint: Update Android SDK from 0.0.16 to 0.0.19
 - maint: Update Swift SDK from 2.1.0 to 2.1.2
 

--- a/src/plugin/withUUIDPlugin.ts
+++ b/src/plugin/withUUIDPlugin.ts
@@ -1,6 +1,5 @@
 import type { ConfigPlugin } from '@expo/config-plugins';
 
-import fs from 'node:fs';
 import withAndroidPlugin from './withUUIDAndroidPlugin';
 import withIOSPlugin from './withUUIDIosPlugin';
 
@@ -9,14 +8,9 @@ const withPlugin: ConfigPlugin = (config) => {
   // Apply Android modifications first
   config = withAndroidPlugin(config, { sourceMapUuid });
   // Then apply iOS modifications and return
-  const resultConfig = withIOSPlugin(config, { sourceMapUuid });
+  config = withIOSPlugin(config, { sourceMapUuid });
 
-  if (!fs.existsSync('./dist/tmp/hny')) {
-    fs.mkdirSync('./dist/tmp/hny', { recursive: true });
-  }
-  fs.writeFileSync('./dist/tmp/hny/SourceMapUuid.txt', sourceMapUuid);
-
-  return resultConfig;
+  return config;
 };
 
 export default withPlugin;


### PR DESCRIPTION
## Which problem is this PR solving?

The UUID plugin currently generates a text file at `./dist/tmp/hny/SourceMapUuid.txt` whenever it's loaded. But that's not how react plugins are supposed to work. The iOS and Android plugins only generate new UUIDs during actual pre-builds. So, often the UUID in the text file doesn't match the one in the code. Using it would cause problems. And using the ones from iOS and Android directly isn't that difficult.

## Short description of the changes

This just removes the text file generation from the plugin. Making the plugin work correctly would be pretty painful.

## How to verify that this has the expected result

Tested manually.

---

- [X] CHANGELOG is updated
N/A ~- [ ] README is updated with documentation~