### PR TITLE
fix: correct the case of the import of withUUIDPlugin to match the actual file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v.Next
 
+- fix: Fix case of withUUIDPlugin import to match file
+
 ## v0.7.2
 
 - fix: Remove `SourceMapUuid.txt` from UUID plugin, because it can be misleading

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/commonjs/plugin/withUUIDplugin');
+module.exports = require('./lib/commonjs/plugin/withUUIDPlugin');


### PR DESCRIPTION

## Which problem is this PR solving?

- Closes #67 

## Short description of the changes

This fixes the case of the import to match the case of the actual file.

## How to verify that this has the expected result

I don't know a great way to test this in this repo. The expo plugin is not used by these tests. We've only tested it as part of building our internal test apps, which we run on macos, which is case-insensitive. I will look into why our CI builds on the internal text apps didn't catch this already. We can consider whether it's worth adding an expo-based example app to this repo.

But this change is so obvious, I don't think we should delay committing the change while I investigate the test situation.

---

- [X] CHANGELOG is updated
n/a ~- [ ] README is updated with documentation~