### PR TITLE
feat: return OpenTelemetryRum from configure() on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: Fix case of withUUIDPlugin import to match file
 - feat: Add example sourcemap upload script.
+- feat: Return `OpenTelemetryRum` from Android `configure()` to allow native-side tracing.
 
 ## v0.7.2
 

--- a/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
+++ b/android/src/main/java/com/honeycombopentelemetryreactnative/HoneycombOpentelemetryReactNativeModule.kt
@@ -63,7 +63,7 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
                 TELEMETRY_DISTRO_NAME.key to "@honeycombio/opentelemetry-react-native"))
     }
 
-    fun configure(app: Application, builder: HoneycombOptions.Builder) {
+    fun configure(app: Application, builder: HoneycombOptions.Builder): OpenTelemetryRum {
       val packageManager = app.packageManager
       val applicationInfo =
         packageManager.getApplicationInfo(
@@ -78,6 +78,7 @@ class HoneycombOpentelemetryReactNativeModule(reactContext: ReactApplicationCont
 
       val options = builder.build()
       otelRum = Honeycomb.configure(app, options)
+      return otelRum!!
     }
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #71

## Short description of the changes

The configure() companion method captures the OpenTelemetryRum instance internally but never exposes it to callers. This prevents apps from obtaining the instance for native-side tracing (e.g. instrumenting a FirebaseMessagingService). Return the instance to match the pattern of the underlying Honeycomb.configure() API.

## How to verify that this has the expected result

I think this is a small change, but I can add a test if necessary? 

---

- [X] CHANGELOG is updated
- [ ] README is updated with documentation (Not sure if needed)

AI Disclaimer: Issue diagnosed and fix proposed with Opus 4.6, I'm not a android developer by any stretch so apologies if this is the wrong direction/I'm missing something totally obvious :) 